### PR TITLE
Add world data containers and bootstrap integration

### DIFF
--- a/Assets/_Project/Scripts/Core/Data.meta
+++ b/Assets/_Project/Scripts/Core/Data.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: db0dbc2425314df9af65f62811d64664
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/Core/Data/WorldData.cs
+++ b/Assets/_Project/Scripts/Core/Data/WorldData.cs
@@ -1,0 +1,378 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Wastelands.Core.Data
+{
+    /// <summary>
+    /// Root snapshot for deterministic world state persistence.
+    /// </summary>
+    [Serializable]
+    public sealed class WorldData
+    {
+        public const int CurrentVersion = 1;
+
+        public int Version { get; set; } = CurrentVersion;
+        public ulong Seed { get; set; }
+        public ApocalypseMeta Apocalypse { get; set; } = new();
+        public List<Tile> Tiles { get; set; } = new();
+        public List<Faction> Factions { get; set; } = new();
+        public List<Settlement> Settlements { get; set; } = new();
+        public List<Character> Characters { get; set; } = new();
+        public List<EventRecord> Events { get; set; } = new();
+        public OracleState OracleState { get; set; } = new();
+        public List<LegendEntry> Legends { get; set; } = new();
+        public BaseState BaseState { get; set; } = new();
+    }
+
+    [Serializable]
+    public sealed class Tile
+    {
+        public string Id { get; set; } = string.Empty;
+        public Int2 Position { get; set; }
+        public float Height { get; set; }
+        public float Temperature { get; set; }
+        public float Moisture { get; set; }
+        public string BiomeId { get; set; } = string.Empty;
+        public List<string> HazardTags { get; set; } = new();
+    }
+
+    [Serializable]
+    public sealed class Faction
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public FactionArchetype Archetype { get; set; }
+        public EthosProfile EthosProfile { get; set; } = new();
+        public List<RelationRecord> Relations { get; set; } = new();
+        public List<NobleRoleAssignment> NobleRoster { get; set; } = new();
+        public List<string> Holdings { get; set; } = new();
+    }
+
+    public enum FactionArchetype
+    {
+        Nomads,
+        Technocracy,
+        Zealots,
+        Mercantile,
+        Raiders,
+        Guardians
+    }
+
+    [Serializable]
+    public struct EthosProfile
+    {
+        public float Compassion { get; set; }
+        public float Ruthlessness { get; set; }
+        public float Tradition { get; set; }
+        public float Innovation { get; set; }
+    }
+
+    [Serializable]
+    public sealed class RelationRecord
+    {
+        public string TargetFactionId { get; set; } = string.Empty;
+        public float Standing { get; set; }
+        public RelationState State { get; set; }
+    }
+
+    public enum RelationState
+    {
+        Allied,
+        Neutral,
+        Hostile
+    }
+
+    [Serializable]
+    public sealed class NobleRoleAssignment
+    {
+        public string CharacterId { get; set; } = string.Empty;
+        public NobleRole Role { get; set; }
+    }
+
+    public enum NobleRole
+    {
+        Overseer,
+        Warlord,
+        Quartermaster,
+        ResearchChief,
+        Steward,
+        DiplomaticEnvoy
+    }
+
+    [Serializable]
+    public sealed class Settlement
+    {
+        public string Id { get; set; } = string.Empty;
+        public string FactionId { get; set; } = string.Empty;
+        public string TileId { get; set; } = string.Empty;
+        public int Population { get; set; }
+        public EconomyProfile Economy { get; set; } = new();
+        public float DefenseRating { get; set; }
+    }
+
+    [Serializable]
+    public struct EconomyProfile
+    {
+        public float Production { get; set; }
+        public float Trade { get; set; }
+        public float Research { get; set; }
+    }
+
+    [Serializable]
+    public sealed class Character
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string FactionId { get; set; } = string.Empty;
+        public List<TraitId> Traits { get; set; } = new();
+        public Dictionary<SkillId, SkillLevel> Skills { get; set; } = new();
+        public List<RelationshipRecord> Relationships { get; set; } = new();
+        public NobleRole? CurrentRole { get; set; }
+        public CharacterStatus Status { get; set; }
+    }
+
+    public enum TraitId
+    {
+        Stoic,
+        Visionary,
+        Pragmatic,
+        Zealous,
+        Empathic,
+        Ruthless
+    }
+
+    public enum SkillId
+    {
+        Tactics,
+        Leadership,
+        Charisma,
+        Organization,
+        Ethos,
+        Industry,
+        Research,
+        Survival
+    }
+
+    [Serializable]
+    public struct SkillLevel
+    {
+        public int Level { get; set; }
+        public float Experience { get; set; }
+        public float Aptitude { get; set; }
+    }
+
+    [Serializable]
+    public sealed class RelationshipRecord
+    {
+        public string TargetId { get; set; } = string.Empty;
+        public RelationshipType Type { get; set; }
+        public int Intensity { get; set; }
+    }
+
+    public enum RelationshipType
+    {
+        Friendship,
+        Rivalry,
+        Mentorship,
+        Kinship
+    }
+
+    public enum CharacterStatus
+    {
+        Active,
+        Missing,
+        Dead
+    }
+
+    [Serializable]
+    public sealed class EventRecord
+    {
+        public string Id { get; set; } = string.Empty;
+        public long Timestamp { get; set; }
+        public EventType EventType { get; set; }
+        public List<string> Actors { get; set; } = new();
+        public string LocationId { get; set; } = string.Empty;
+        public Dictionary<string, string> Details { get; set; } = new();
+    }
+
+    public enum EventType
+    {
+        Battle,
+        Discovery,
+        Mandate,
+        Raid,
+        Research,
+        Catastrophe
+    }
+
+    [Serializable]
+    public sealed class LegendEntry
+    {
+        public string Id { get; set; } = string.Empty;
+        public List<string> EventIds { get; set; } = new();
+        public string Summary { get; set; } = string.Empty;
+    }
+
+    [Serializable]
+    public sealed class OracleState
+    {
+        public string ActiveDeckId { get; set; } = string.Empty;
+        public float TensionScore { get; set; }
+        public Dictionary<string, long> Cooldowns { get; set; } = new();
+        public List<EventDeck> AvailableDecks { get; set; } = new();
+    }
+
+    [Serializable]
+    public sealed class EventDeck
+    {
+        public string Id { get; set; } = string.Empty;
+        public OracleDeckTier Tier { get; set; }
+        public float Weight { get; set; }
+        public List<EventCard> Cards { get; set; } = new();
+    }
+
+    public enum OracleDeckTier
+    {
+        Minor,
+        Major,
+        Epic
+    }
+
+    [Serializable]
+    public sealed class EventCard
+    {
+        public string Id { get; set; } = string.Empty;
+        public List<EventEffect> Effects { get; set; } = new();
+        public string Narrative { get; set; } = string.Empty;
+    }
+
+    [Serializable]
+    public sealed class EventEffect
+    {
+        public string EffectType { get; set; } = string.Empty;
+        public Dictionary<string, string> Parameters { get; set; } = new();
+    }
+
+    [Serializable]
+    public sealed class ApocalypseMeta
+    {
+        public ApocalypseType Type { get; set; }
+        public float Severity { get; set; }
+        public string OriginTileId { get; set; } = string.Empty;
+        public List<EraEvent> EraTimeline { get; set; } = new();
+    }
+
+    public enum ApocalypseType
+    {
+        RadiantStorm,
+        NanoPlague,
+        ArcaneSundering,
+        VoidBlight
+    }
+
+    [Serializable]
+    public sealed class EraEvent
+    {
+        public long Timestamp { get; set; }
+        public string Description { get; set; } = string.Empty;
+    }
+
+    [Serializable]
+    public sealed class BaseState
+    {
+        public bool Active { get; set; }
+        public string SiteTileId { get; set; } = string.Empty;
+        public List<BaseZone> Zones { get; set; } = new();
+        public List<string> Population { get; set; } = new();
+        public Dictionary<string, float> Infrastructure { get; set; } = new();
+        public AlertLevel AlertLevel { get; set; }
+        public List<ItemStack> Inventory { get; set; } = new();
+        public ResearchState Research { get; set; } = new();
+    }
+
+    [Serializable]
+    public sealed class BaseZone
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public ZoneType Type { get; set; }
+        public float Efficiency { get; set; }
+    }
+
+    public enum ZoneType
+    {
+        Habitat,
+        Workshop,
+        Farm,
+        Watchtower,
+        ResearchLab
+    }
+
+    public enum AlertLevel
+    {
+        Calm,
+        Elevated,
+        Critical
+    }
+
+    [Serializable]
+    public sealed class ItemStack
+    {
+        public string ItemId { get; set; } = string.Empty;
+        public int Quantity { get; set; }
+    }
+
+    [Serializable]
+    public sealed class ResearchState
+    {
+        public List<string> CompletedProjects { get; set; } = new();
+        public string ActiveProjectId { get; set; } = string.Empty;
+        public float ActiveProgress { get; set; }
+    }
+
+    /// <summary>
+    /// Simple integer coordinate struct to avoid Unity dependencies.
+    /// </summary>
+    [Serializable]
+    public struct Int2 : IEquatable<Int2>
+    {
+        public Int2(int x, int y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        public int X { get; set; }
+        public int Y { get; set; }
+
+        public bool Equals(Int2 other) => X == other.X && Y == other.Y;
+
+        public override bool Equals(object? obj) => obj is Int2 other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(X, Y);
+
+        public override string ToString() => $"({X}, {Y})";
+    }
+
+    internal static class DictionaryExtensions
+    {
+        public static void SortKeysInPlace<T>(this IDictionary<string, T> dictionary)
+        {
+            if (dictionary.Count <= 1)
+            {
+                return;
+            }
+
+            var ordered = dictionary
+                .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+                .ToArray();
+
+            dictionary.Clear();
+            foreach (var pair in ordered)
+            {
+                dictionary[pair.Key] = pair.Value;
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Core/Data/WorldData.cs.meta
+++ b/Assets/_Project/Scripts/Core/Data/WorldData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 75f635a49c06426c8a07e545092c9d3b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/Core/Data/WorldDataNormalizer.cs
+++ b/Assets/_Project/Scripts/Core/Data/WorldDataNormalizer.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Wastelands.Core.Data
+{
+    /// <summary>
+    /// Ensures collections within <see cref="WorldData"/> follow deterministic ordering before serialization.
+    /// </summary>
+    public static class WorldDataNormalizer
+    {
+        public static void Normalize(WorldData world)
+        {
+            if (world == null)
+            {
+                throw new ArgumentNullException(nameof(world));
+            }
+
+            world.Tiles ??= new List<Tile>();
+            world.Factions ??= new List<Faction>();
+            world.Settlements ??= new List<Settlement>();
+            world.Characters ??= new List<Character>();
+            world.Events ??= new List<EventRecord>();
+            world.Legends ??= new List<LegendEntry>();
+            world.Apocalypse ??= new ApocalypseMeta();
+            world.Apocalypse.EraTimeline ??= new List<EraEvent>();
+            world.OracleState ??= new OracleState();
+            world.OracleState.AvailableDecks ??= new List<EventDeck>();
+            world.OracleState.Cooldowns ??= new Dictionary<string, long>();
+            world.BaseState ??= new BaseState();
+            world.BaseState.Zones ??= new List<BaseZone>();
+            world.BaseState.Population ??= new List<string>();
+            world.BaseState.Infrastructure ??= new Dictionary<string, float>();
+            world.BaseState.Inventory ??= new List<ItemStack>();
+            world.BaseState.Research ??= new ResearchState();
+            world.BaseState.Research.CompletedProjects ??= new List<string>();
+
+            world.Tiles = world.Tiles
+                .OrderBy(t => t.Id, StringComparer.Ordinal)
+                .ToList();
+
+            world.Factions = world.Factions
+                .OrderBy(f => f.Id, StringComparer.Ordinal)
+                .ToList();
+
+            foreach (var faction in world.Factions)
+            {
+                faction.Relations = faction.Relations
+                    .OrderBy(r => r.TargetFactionId, StringComparer.Ordinal)
+                    .ToList();
+
+                faction.NobleRoster = faction.NobleRoster
+                    .OrderBy(r => r.Role)
+                    .ThenBy(r => r.CharacterId, StringComparer.Ordinal)
+                    .ToList();
+
+                faction.Holdings = faction.Holdings
+                    .OrderBy(id => id, StringComparer.Ordinal)
+                    .ToList();
+            }
+
+            world.Settlements = world.Settlements
+                .OrderBy(s => s.Id, StringComparer.Ordinal)
+                .ToList();
+
+            world.Characters = world.Characters
+                .OrderBy(c => c.Id, StringComparer.Ordinal)
+                .ToList();
+
+            foreach (var character in world.Characters)
+            {
+                character.Traits ??= new List<TraitId>();
+                character.Skills ??= new Dictionary<SkillId, SkillLevel>();
+                character.Relationships ??= new List<RelationshipRecord>();
+
+                character.Traits = character.Traits
+                    .OrderBy(t => t)
+                    .ToList();
+
+                if (character.Skills.Count > 1)
+                {
+                    var orderedSkills = character.Skills
+                        .OrderBy(pair => pair.Key)
+                        .ToArray();
+
+                    character.Skills.Clear();
+                    foreach (var (skill, level) in orderedSkills)
+                    {
+                        character.Skills[skill] = level;
+                    }
+                }
+
+                character.Relationships = character.Relationships
+                    .OrderBy(r => r.TargetId, StringComparer.Ordinal)
+                    .ThenBy(r => r.Type)
+                    .ToList();
+            }
+
+            world.Events = world.Events
+                .OrderBy(e => e.Timestamp)
+                .ThenBy(e => e.Id, StringComparer.Ordinal)
+                .ToList();
+
+            foreach (var @event in world.Events)
+            {
+                @event.Actors ??= new List<string>();
+                @event.Details ??= new Dictionary<string, string>();
+
+                @event.Actors = @event.Actors
+                    .OrderBy(id => id, StringComparer.Ordinal)
+                    .ToList();
+
+                @event.Details.SortKeysInPlace();
+            }
+
+            world.OracleState.Cooldowns.SortKeysInPlace();
+
+            world.OracleState.AvailableDecks = world.OracleState.AvailableDecks
+                .OrderBy(deck => deck.Tier)
+                .ThenBy(deck => deck.Id, StringComparer.Ordinal)
+                .ToList();
+
+            foreach (var deck in world.OracleState.AvailableDecks)
+            {
+                deck.Cards ??= new List<EventCard>();
+
+                deck.Cards = deck.Cards
+                    .OrderBy(card => card.Id, StringComparer.Ordinal)
+                    .ToList();
+
+                foreach (var card in deck.Cards)
+                {
+                    card.Effects ??= new List<EventEffect>();
+
+                    card.Effects = card.Effects
+                        .OrderBy(effect => effect.EffectType, StringComparer.Ordinal)
+                        .ThenBy(effect => effect.Narrative, StringComparer.Ordinal)
+                        .ToList();
+
+                    foreach (var effect in card.Effects)
+                    {
+                        effect.Parameters ??= new Dictionary<string, string>();
+                        effect.Parameters.SortKeysInPlace();
+                    }
+                }
+            }
+
+            world.Legends = world.Legends
+                .OrderBy(l => l.Id, StringComparer.Ordinal)
+                .ToList();
+
+            foreach (var legend in world.Legends)
+            {
+                legend.EventIds ??= new List<string>();
+
+                legend.EventIds = legend.EventIds
+                    .OrderBy(id => id, StringComparer.Ordinal)
+                    .ToList();
+            }
+
+            if (world.Apocalypse.EraTimeline.Count > 1)
+            {
+                world.Apocalypse.EraTimeline = world.Apocalypse.EraTimeline
+                    .OrderBy(e => e.Timestamp)
+                    .ThenBy(e => e.Description, StringComparer.Ordinal)
+                    .ToList();
+            }
+
+            var baseState = world.BaseState ?? new BaseState();
+            baseState.Zones = baseState.Zones
+                .OrderBy(z => z.Id, StringComparer.Ordinal)
+                .ToList();
+
+            baseState.Population = baseState.Population
+                .OrderBy(id => id, StringComparer.Ordinal)
+                .ToList();
+
+            baseState.Infrastructure.SortKeysInPlace();
+
+            baseState.Inventory = baseState.Inventory
+                .OrderBy(stack => stack.ItemId, StringComparer.Ordinal)
+                .ToList();
+
+            baseState.Research.CompletedProjects = baseState.Research.CompletedProjects
+                .OrderBy(id => id, StringComparer.Ordinal)
+                .ToList();
+
+            world.BaseState = baseState;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Core/Data/WorldDataNormalizer.cs.meta
+++ b/Assets/_Project/Scripts/Core/Data/WorldDataNormalizer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 18fc7be75f15430095788829695351ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/Core/Data/WorldDataValidator.cs
+++ b/Assets/_Project/Scripts/Core/Data/WorldDataValidator.cs
@@ -1,0 +1,288 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Wastelands.Core.Data
+{
+    public sealed class WorldDataValidator
+    {
+        public ValidationResult Validate(WorldData world)
+        {
+            var errors = new List<string>();
+            if (world == null)
+            {
+                errors.Add("World data is null.");
+                return ValidationResult.FromErrors(errors);
+            }
+
+            WorldDataNormalizer.Normalize(world);
+
+            ValidateTiles(world, errors);
+            ValidateFactions(world, errors);
+            ValidateSettlements(world, errors);
+            ValidateCharacters(world, errors);
+            ValidateEvents(world, errors);
+            ValidateLegends(world, errors);
+            ValidateOracle(world, errors);
+            ValidateBaseState(world, errors);
+
+            return errors.Count == 0 ? ValidationResult.Success() : ValidationResult.FromErrors(errors);
+        }
+
+        private static void ValidateTiles(WorldData world, ICollection<string> errors)
+        {
+            if (!EnsureUnique(world.Tiles.Select(t => t.Id), "Tile", errors))
+            {
+                return;
+            }
+
+            foreach (var tile in world.Tiles)
+            {
+                if (string.IsNullOrWhiteSpace(tile.Id))
+                {
+                    errors.Add("Tile ID must not be empty.");
+                }
+            }
+        }
+
+        private static void ValidateFactions(WorldData world, ICollection<string> errors)
+        {
+            if (!EnsureUnique(world.Factions.Select(f => f.Id), "Faction", errors))
+            {
+                return;
+            }
+
+            var factionIds = new HashSet<string>(world.Factions.Select(f => f.Id), StringComparer.Ordinal);
+            foreach (var faction in world.Factions)
+            {
+                if (string.IsNullOrWhiteSpace(faction.Id))
+                {
+                    errors.Add("Faction ID must not be empty.");
+                }
+
+                foreach (var relation in faction.Relations)
+                {
+                    if (!factionIds.Contains(relation.TargetFactionId))
+                    {
+                        errors.Add($"Faction relation points to unknown faction '{relation.TargetFactionId}'.");
+                    }
+                }
+
+                foreach (var roster in faction.NobleRoster)
+                {
+                    if (string.IsNullOrWhiteSpace(roster.CharacterId))
+                    {
+                        errors.Add($"Faction '{faction.Id}' has a noble role without character id.");
+                    }
+                }
+
+                foreach (var holding in faction.Holdings)
+                {
+                    if (!world.Settlements.Any(s => s.Id == holding))
+                    {
+                        errors.Add($"Faction '{faction.Id}' references unknown settlement '{holding}'.");
+                    }
+                }
+            }
+        }
+
+        private static void ValidateSettlements(WorldData world, ICollection<string> errors)
+        {
+            if (!EnsureUnique(world.Settlements.Select(s => s.Id), "Settlement", errors))
+            {
+                return;
+            }
+
+            var factionIds = new HashSet<string>(world.Factions.Select(f => f.Id), StringComparer.Ordinal);
+            var tileIds = new HashSet<string>(world.Tiles.Select(t => t.Id), StringComparer.Ordinal);
+
+            foreach (var settlement in world.Settlements)
+            {
+                if (!factionIds.Contains(settlement.FactionId))
+                {
+                    errors.Add($"Settlement '{settlement.Id}' references unknown faction '{settlement.FactionId}'.");
+                }
+
+                if (!tileIds.Contains(settlement.TileId))
+                {
+                    errors.Add($"Settlement '{settlement.Id}' references unknown tile '{settlement.TileId}'.");
+                }
+            }
+        }
+
+        private static void ValidateCharacters(WorldData world, ICollection<string> errors)
+        {
+            if (!EnsureUnique(world.Characters.Select(c => c.Id), "Character", errors))
+            {
+                return;
+            }
+
+            var factionIds = new HashSet<string>(world.Factions.Select(f => f.Id), StringComparer.Ordinal);
+            var characterIds = new HashSet<string>(world.Characters.Select(c => c.Id), StringComparer.Ordinal);
+
+            foreach (var character in world.Characters)
+            {
+                if (!factionIds.Contains(character.FactionId))
+                {
+                    errors.Add($"Character '{character.Id}' references unknown faction '{character.FactionId}'.");
+                }
+
+                foreach (var relationship in character.Relationships)
+                {
+                    if (!characterIds.Contains(relationship.TargetId))
+                    {
+                        errors.Add($"Character '{character.Id}' has relationship to unknown character '{relationship.TargetId}'.");
+                    }
+                }
+            }
+
+            foreach (var faction in world.Factions)
+            {
+                foreach (var roster in faction.NobleRoster)
+                {
+                    if (!characterIds.Contains(roster.CharacterId))
+                    {
+                        errors.Add($"Faction '{faction.Id}' assigns noble role '{roster.Role}' to unknown character '{roster.CharacterId}'.");
+                    }
+                }
+            }
+        }
+
+        private static void ValidateEvents(WorldData world, ICollection<string> errors)
+        {
+            if (!EnsureUnique(world.Events.Select(e => e.Id), "Event", errors))
+            {
+                return;
+            }
+
+            var characterIds = new HashSet<string>(world.Characters.Select(c => c.Id), StringComparer.Ordinal);
+            var tileIds = new HashSet<string>(world.Tiles.Select(t => t.Id), StringComparer.Ordinal);
+            var settlementIds = new HashSet<string>(world.Settlements.Select(s => s.Id), StringComparer.Ordinal);
+
+            foreach (var record in world.Events)
+            {
+                foreach (var actor in record.Actors)
+                {
+                    if (!characterIds.Contains(actor))
+                    {
+                        errors.Add($"Event '{record.Id}' references unknown character '{actor}'.");
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(record.LocationId))
+                {
+                    var valid = tileIds.Contains(record.LocationId) || settlementIds.Contains(record.LocationId) ||
+                                string.Equals(record.LocationId, world.BaseState.SiteTileId, StringComparison.Ordinal);
+
+                    if (!valid)
+                    {
+                        errors.Add($"Event '{record.Id}' references unknown location '{record.LocationId}'.");
+                    }
+                }
+            }
+        }
+
+        private static void ValidateLegends(WorldData world, ICollection<string> errors)
+        {
+            if (!EnsureUnique(world.Legends.Select(l => l.Id), "Legend", errors))
+            {
+                return;
+            }
+
+            var eventIds = new HashSet<string>(world.Events.Select(e => e.Id), StringComparer.Ordinal);
+            foreach (var legend in world.Legends)
+            {
+                foreach (var id in legend.EventIds)
+                {
+                    if (!eventIds.Contains(id))
+                    {
+                        errors.Add($"Legend '{legend.Id}' references unknown event '{id}'.");
+                    }
+                }
+            }
+        }
+
+        private static void ValidateOracle(WorldData world, ICollection<string> errors)
+        {
+            var deckIds = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var deck in world.OracleState.AvailableDecks)
+            {
+                if (!deckIds.Add(deck.Id))
+                {
+                    errors.Add($"Oracle deck id '{deck.Id}' is duplicated.");
+                }
+
+                var cardIds = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var card in deck.Cards)
+                {
+                    if (!cardIds.Add(card.Id))
+                    {
+                        errors.Add($"Deck '{deck.Id}' has duplicate card id '{card.Id}'.");
+                    }
+                }
+            }
+        }
+
+        private static void ValidateBaseState(WorldData world, ICollection<string> errors)
+        {
+            var baseState = world.BaseState;
+            if (baseState == null)
+            {
+                errors.Add("Base state is missing.");
+                return;
+            }
+
+            var zoneIds = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var zone in baseState.Zones)
+            {
+                if (!zoneIds.Add(zone.Id))
+                {
+                    errors.Add($"Base zone id '{zone.Id}' is duplicated.");
+                }
+            }
+
+            var characterIds = new HashSet<string>(world.Characters.Select(c => c.Id), StringComparer.Ordinal);
+            foreach (var member in baseState.Population)
+            {
+                if (!characterIds.Contains(member))
+                {
+                    errors.Add($"Base population references unknown character '{member}'.");
+                }
+            }
+        }
+
+        private static bool EnsureUnique(IEnumerable<string> ids, string label, ICollection<string> errors)
+        {
+            var set = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var id in ids)
+            {
+                if (!set.Add(id))
+                {
+                    errors.Add($"Duplicate {label} id '{id}'.");
+                }
+            }
+
+            return errors.Count == 0;
+        }
+    }
+
+    public readonly struct ValidationResult
+    {
+        private ValidationResult(bool isValid, IReadOnlyList<string> errors)
+        {
+            IsValid = isValid;
+            Errors = errors;
+        }
+
+        public bool IsValid { get; }
+        public IReadOnlyList<string> Errors { get; }
+
+        public static ValidationResult Success() => new(true, Array.Empty<string>());
+
+        public static ValidationResult FromErrors(IEnumerable<string> errors)
+        {
+            var list = errors.ToArray();
+            return new ValidationResult(list.Length == 0, list);
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Core/Data/WorldDataValidator.cs.meta
+++ b/Assets/_Project/Scripts/Core/Data/WorldDataValidator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f8a1842a8d649fe8587c26df985fe46
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/Core/Management/DeterministicServiceContainer.cs
+++ b/Assets/_Project/Scripts/Core/Management/DeterministicServiceContainer.cs
@@ -1,0 +1,52 @@
+using System;
+using Wastelands.Core.Services;
+
+namespace Wastelands.Core.Management
+{
+    /// <summary>
+    /// Aggregate of deterministic runtime services shared across scenes.
+    /// </summary>
+    public sealed class DeterministicServiceContainer
+    {
+        public DeterministicServiceContainer(ITimeProvider timeProvider, IRngService rngService, IEventBus eventBus, ITickManager tickManager)
+        {
+            TimeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+            RngService = rngService ?? throw new ArgumentNullException(nameof(rngService));
+            EventBus = eventBus ?? throw new ArgumentNullException(nameof(eventBus));
+            TickManager = tickManager ?? throw new ArgumentNullException(nameof(tickManager));
+        }
+
+        public ITimeProvider TimeProvider { get; }
+        public IRngService RngService { get; }
+        public IEventBus EventBus { get; }
+        public ITickManager TickManager { get; }
+    }
+
+    /// <summary>
+    /// Lightweight static provider to bridge Unity scenes until a DI container is introduced.
+    /// </summary>
+    public static class DeterministicServicesProvider
+    {
+        private static DeterministicServiceContainer? _container;
+
+        public static DeterministicServiceContainer Container
+        {
+            get
+            {
+                if (_container == null)
+                {
+                    throw new InvalidOperationException("Deterministic services have not been initialized.");
+                }
+
+                return _container;
+            }
+        }
+
+        public static void SetContainer(DeterministicServiceContainer container)
+        {
+            _container = container ?? throw new ArgumentNullException(nameof(container));
+        }
+
+        public static void Clear() => _container = null;
+    }
+}

--- a/Assets/_Project/Scripts/Core/Management/DeterministicServiceContainer.cs.meta
+++ b/Assets/_Project/Scripts/Core/Management/DeterministicServiceContainer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 231e5e1e024442b1ae18aecf48d9ff12
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/Persistence/WorldDataSerializer.cs
+++ b/Assets/_Project/Scripts/Persistence/WorldDataSerializer.cs
@@ -1,0 +1,76 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using Wastelands.Core.Data;
+
+namespace Wastelands.Persistence
+{
+    public interface IWorldDataSerializer
+    {
+        string Serialize(WorldData data);
+        void SerializeToStream(WorldData data, Stream stream);
+        WorldData Deserialize(string json);
+        WorldData DeserializeFromStream(Stream stream);
+    }
+
+    /// <summary>
+    /// JSON serializer for <see cref="WorldData"/> snapshots ensuring deterministic ordering.
+    /// </summary>
+    public sealed class WorldDataSerializer : IWorldDataSerializer
+    {
+        private static readonly JsonSerializerOptions Options = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true,
+        };
+
+        public string Serialize(WorldData data)
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            WorldDataNormalizer.Normalize(data);
+            return JsonSerializer.Serialize(data, Options);
+        }
+
+        public void SerializeToStream(WorldData data, Stream stream)
+        {
+            if (stream == null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            var json = Serialize(data);
+            using var writer = new StreamWriter(stream, new UTF8Encoding(false), leaveOpen: true);
+            writer.Write(json);
+            writer.Flush();
+        }
+
+        public WorldData Deserialize(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                throw new ArgumentException("JSON payload must be provided.", nameof(json));
+            }
+
+            var world = JsonSerializer.Deserialize<WorldData>(json, Options) ?? throw new InvalidOperationException("Failed to deserialize world data.");
+            WorldDataNormalizer.Normalize(world);
+            return world;
+        }
+
+        public WorldData DeserializeFromStream(Stream stream)
+        {
+            if (stream == null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            using var reader = new StreamReader(stream, Encoding.UTF8, leaveOpen: true);
+            var json = reader.ReadToEnd();
+            return Deserialize(json);
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Persistence/WorldDataSerializer.cs.meta
+++ b/Assets/_Project/Scripts/Persistence/WorldDataSerializer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb340fe8c8554809a284de7bb8f3e67b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/UI/Bootstrap.meta
+++ b/Assets/_Project/Scripts/UI/Bootstrap.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 190c535cd2864fdea1eeb3d4372dc13c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/UI/Bootstrap/DeterministicBootstrapper.cs
+++ b/Assets/_Project/Scripts/UI/Bootstrap/DeterministicBootstrapper.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+using Wastelands.Core.Management;
+
+namespace Wastelands.UI.Bootstrap
+{
+    /// <summary>
+    /// MonoBehaviour placed in the Boot scene to install deterministic services at startup.
+    /// </summary>
+    public sealed class DeterministicBootstrapper : MonoBehaviour
+    {
+        [SerializeField] private DeterministicServiceInstaller? installer;
+
+        private void Awake()
+        {
+            if (installer == null)
+            {
+                Debug.LogError("DeterministicBootstrapper missing installer reference.");
+                return;
+            }
+
+            installer.Install();
+            DontDestroyOnLoad(gameObject);
+        }
+
+        private void OnDestroy()
+        {
+            if (!Application.isPlaying)
+            {
+                return;
+            }
+
+            DeterministicServicesProvider.Clear();
+        }
+    }
+}

--- a/Assets/_Project/Scripts/UI/Bootstrap/DeterministicBootstrapper.cs.meta
+++ b/Assets/_Project/Scripts/UI/Bootstrap/DeterministicBootstrapper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 341c1819f1d846c8b8f12835acdd959b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/UI/Bootstrap/DeterministicServiceInstaller.cs
+++ b/Assets/_Project/Scripts/UI/Bootstrap/DeterministicServiceInstaller.cs
@@ -1,0 +1,52 @@
+using System;
+using UnityEngine;
+using Wastelands.Core.Management;
+using Wastelands.Core.Services;
+
+namespace Wastelands.UI.Bootstrap
+{
+    /// <summary>
+    /// Scriptable object used by the Boot scene to configure deterministic services.
+    /// </summary>
+    [CreateAssetMenu(fileName = "DeterministicServiceInstaller", menuName = "Wastelands/Deterministic Service Installer")]
+    public sealed class DeterministicServiceInstaller : ScriptableObject
+    {
+        [Header("Seed & Timing")] [SerializeField] private int seed = 12345;
+        [SerializeField] private int ticksPerYear = 1;
+        [SerializeField] private long ticksPerDay = 24;
+
+        [NonSerialized] private DeterministicServiceContainer? _container;
+
+        public DeterministicServiceContainer Install()
+        {
+            if (_container != null)
+            {
+                DeterministicServicesProvider.SetContainer(_container);
+                return _container;
+            }
+
+            var timeProvider = new ManualTimeProvider(ticksPerYear, ticksPerDay);
+            var rngService = new DeterministicRngService(seed);
+            var eventBus = new EventBus();
+            var tickManager = new TickManager(timeProvider, rngService, eventBus);
+            _container = new DeterministicServiceContainer(timeProvider, rngService, eventBus, tickManager);
+            DeterministicServicesProvider.SetContainer(_container);
+            return _container;
+        }
+
+        public void ResetContainer()
+        {
+            _container = null;
+            DeterministicServicesProvider.Clear();
+        }
+
+        public void ConfigureSeed(int newSeed)
+        {
+            seed = newSeed;
+            if (_container != null)
+            {
+                _container.RngService.Reset(newSeed);
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/UI/Bootstrap/DeterministicServiceInstaller.cs.meta
+++ b/Assets/_Project/Scripts/UI/Bootstrap/DeterministicServiceInstaller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 51e79dc4518c440c99ce3627e83d0358
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/EditMode/DeterministicServiceInstallerTests.cs
+++ b/Tests/EditMode/DeterministicServiceInstallerTests.cs
@@ -1,0 +1,50 @@
+using NUnit.Framework;
+using UnityEngine;
+using Wastelands.Core.Management;
+using Wastelands.UI.Bootstrap;
+
+namespace Wastelands.Tests.EditMode
+{
+    public class DeterministicServiceInstallerTests
+    {
+        [Test]
+        public void Install_RegistersContainerWithProvider()
+        {
+            var installer = ScriptableObject.CreateInstance<DeterministicServiceInstaller>();
+
+            try
+            {
+                var container = installer.Install();
+
+                Assert.IsNotNull(container.TimeProvider);
+                Assert.IsNotNull(DeterministicServicesProvider.Container);
+            }
+            finally
+            {
+                installer.ResetContainer();
+                ScriptableObject.DestroyImmediate(installer);
+            }
+        }
+
+        [Test]
+        public void ConfigureSeed_UpdatesUnderlyingRng()
+        {
+            var installer = ScriptableObject.CreateInstance<DeterministicServiceInstaller>();
+
+            try
+            {
+                var container = installer.Install();
+                var original = container.RngService.Seed;
+
+                installer.ConfigureSeed(original + 1);
+
+                Assert.AreEqual(original + 1, container.RngService.Seed);
+            }
+            finally
+            {
+                installer.ResetContainer();
+                ScriptableObject.DestroyImmediate(installer);
+            }
+        }
+    }
+}

--- a/Tests/EditMode/SampleWorldBuilder.cs
+++ b/Tests/EditMode/SampleWorldBuilder.cs
@@ -1,0 +1,150 @@
+using System.Collections.Generic;
+using Wastelands.Core.Data;
+
+namespace Wastelands.Tests.EditMode
+{
+    internal static class SampleWorldBuilder
+    {
+        public static WorldData CreateValidWorld()
+        {
+            var tile = new Tile
+            {
+                Id = "tile_0_0",
+                Position = new Int2(0, 0),
+                BiomeId = "biome_desert",
+                HazardTags = new List<string> { "dust" }
+            };
+
+            var faction = new Faction
+            {
+                Id = "fac_alpha",
+                Name = "Alpha",
+                Archetype = FactionArchetype.Nomads,
+                NobleRoster = new List<NobleRoleAssignment>(),
+                Relations = new List<RelationRecord>()
+            };
+
+            var settlement = new Settlement
+            {
+                Id = "set_01",
+                FactionId = faction.Id,
+                TileId = tile.Id,
+                Population = 100,
+                Economy = new EconomyProfile { Production = 1f, Trade = 1f, Research = 0.2f }
+            };
+
+            var character = new Character
+            {
+                Id = "char_leader",
+                Name = "Leader",
+                FactionId = faction.Id,
+                Traits = new List<TraitId> { TraitId.Stoic },
+                Skills = new Dictionary<SkillId, SkillLevel>
+                {
+                    { SkillId.Leadership, new SkillLevel { Level = 3, Experience = 10, Aptitude = 1.1f } }
+                },
+                Relationships = new List<RelationshipRecord>()
+            };
+
+            faction.NobleRoster.Add(new NobleRoleAssignment { CharacterId = character.Id, Role = NobleRole.Overseer });
+            faction.Holdings.Add(settlement.Id);
+
+            var world = new WorldData
+            {
+                Seed = 42,
+                Tiles = new List<Tile> { tile },
+                Factions = new List<Faction> { faction },
+                Settlements = new List<Settlement> { settlement },
+                Characters = new List<Character> { character },
+                Events = new List<EventRecord>
+                {
+                    new()
+                    {
+                        Id = "event_01",
+                        Timestamp = 1,
+                        EventType = EventType.Discovery,
+                        Actors = new List<string> { character.Id },
+                        LocationId = tile.Id,
+                        Details = new Dictionary<string, string> { { "resource", "water" } }
+                    }
+                },
+                OracleState = new OracleState
+                {
+                    ActiveDeckId = "deck_minor_01",
+                    TensionScore = 0.5f,
+                    Cooldowns = new Dictionary<string, long> { { "card_rise_nemesis", 10 } },
+                    AvailableDecks = new List<EventDeck>
+                    {
+                        new()
+                        {
+                            Id = "deck_minor_01",
+                            Tier = OracleDeckTier.Minor,
+                            Weight = 1f,
+                            Cards = new List<EventCard>
+                            {
+                                new()
+                                {
+                                    Id = "card_rise_nemesis",
+                                    Narrative = "Nemesis stirs",
+                                    Effects = new List<EventEffect>
+                                    {
+                                        new()
+                                        {
+                                            EffectType = "spawn_event",
+                                            Parameters = new Dictionary<string, string> { { "target", settlement.Id } }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                Legends = new List<LegendEntry>
+                {
+                    new()
+                    {
+                        Id = "legend_01",
+                        Summary = "Found water",
+                        EventIds = new List<string> { "event_01" }
+                    }
+                },
+                Apocalypse = new ApocalypseMeta
+                {
+                    Type = ApocalypseType.RadiantStorm,
+                    Severity = 0.7f,
+                    OriginTileId = tile.Id,
+                    EraTimeline = new List<EraEvent>
+                    {
+                        new() { Timestamp = 0, Description = "Storm begins" }
+                    }
+                },
+                BaseState = new BaseState
+                {
+                    Active = true,
+                    SiteTileId = tile.Id,
+                    Zones = new List<BaseZone>
+                    {
+                        new() { Id = "zone_hab", Name = "Hab", Type = ZoneType.Habitat, Efficiency = 1f }
+                    },
+                    Population = new List<string> { character.Id },
+                    Infrastructure = new Dictionary<string, float> { { "power", 1f } },
+                    Inventory = new List<ItemStack>
+                    {
+                        new() { ItemId = "water", Quantity = 10 }
+                    },
+                    AlertLevel = AlertLevel.Calm,
+                    Research = new ResearchState
+                    {
+                        CompletedProjects = new List<string> { "tech_filters" },
+                        ActiveProjectId = "tech_drills",
+                        ActiveProgress = 0.5f
+                    }
+                }
+            };
+
+            faction.Relations.Add(new RelationRecord { TargetFactionId = faction.Id, Standing = 1f, State = RelationState.Allied });
+
+            return world;
+        }
+    }
+}

--- a/Tests/EditMode/Wastelands.Tests.EditMode.asmdef
+++ b/Tests/EditMode/Wastelands.Tests.EditMode.asmdef
@@ -2,6 +2,8 @@
   "name": "Wastelands.Tests.EditMode",
   "references": [
     "Wastelands.Core",
+    "Wastelands.Persistence",
+    "Wastelands.UI",
     "UnityEngine.TestRunner",
     "UnityEditor.TestRunner"
   ],

--- a/Tests/EditMode/WorldDataSerializerTests.cs
+++ b/Tests/EditMode/WorldDataSerializerTests.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Wastelands.Core.Data;
+using Wastelands.Persistence;
+
+namespace Wastelands.Tests.EditMode
+{
+    public class WorldDataSerializerTests
+    {
+        [Test]
+        public void Serialize_ProducesDeterministicOrdering()
+        {
+            var world = SampleWorldBuilder.CreateValidWorld();
+            var worldCopy = SampleWorldBuilder.CreateValidWorld();
+
+            var supportA = new Character
+            {
+                Id = "char_support",
+                Name = "Support",
+                FactionId = world.Factions[0].Id,
+                Traits = new List<TraitId>(),
+                Skills = new Dictionary<SkillId, SkillLevel>(),
+                Relationships = new List<RelationshipRecord>()
+            };
+
+            var supportB = new Character
+            {
+                Id = "char_support",
+                Name = "Support",
+                FactionId = worldCopy.Factions[0].Id,
+                Traits = new List<TraitId>(),
+                Skills = new Dictionary<SkillId, SkillLevel>(),
+                Relationships = new List<RelationshipRecord>()
+            };
+
+            world.Characters.Add(supportA);
+            worldCopy.Characters.Insert(0, supportB);
+
+            world.Events[0].Details = new Dictionary<string, string>
+            {
+                { "beta", "2" },
+                { "alpha", "1" }
+            };
+
+            worldCopy.Events[0].Details = new Dictionary<string, string>
+            {
+                { "alpha", "1" },
+                { "beta", "2" }
+            };
+
+            world.OracleState.AvailableDecks[0].Cards.Add(new EventCard
+            {
+                Id = "card_extra",
+                Narrative = "Extra",
+                Effects = new()
+                {
+                    new EventEffect { EffectType = "boost", Parameters = new Dictionary<string, string> { { "value", "5" } } }
+                }
+            });
+
+            worldCopy.OracleState.AvailableDecks[0].Cards.Insert(0, new EventCard
+            {
+                Id = "card_extra",
+                Narrative = "Extra",
+                Effects = new()
+                {
+                    new EventEffect { EffectType = "boost", Parameters = new Dictionary<string, string> { { "value", "5" } } }
+                }
+            });
+
+            var serializer = new WorldDataSerializer();
+            var jsonA = serializer.Serialize(world);
+            var jsonB = serializer.Serialize(worldCopy);
+
+            Assert.AreEqual(jsonB, jsonA);
+        }
+
+        [Test]
+        public void Deserialize_NormalizesCollections()
+        {
+            var serializer = new WorldDataSerializer();
+            var world = SampleWorldBuilder.CreateValidWorld();
+            world.Events[0].Actors.Insert(0, "zzz");
+            var json = serializer.Serialize(world);
+
+            var result = serializer.Deserialize(json);
+
+            Assert.That(result.Events[0].Actors[0], Is.EqualTo("char_leader"));
+            Assert.That(result.Characters[0].Id, Is.EqualTo("char_leader"));
+        }
+    }
+}

--- a/Tests/EditMode/WorldDataValidatorTests.cs
+++ b/Tests/EditMode/WorldDataValidatorTests.cs
@@ -1,0 +1,45 @@
+using NUnit.Framework;
+using Wastelands.Core.Data;
+
+namespace Wastelands.Tests.EditMode
+{
+    public class WorldDataValidatorTests
+    {
+        [Test]
+        public void Validate_ReturnsSuccess_ForConsistentData()
+        {
+            var world = SampleWorldBuilder.CreateValidWorld();
+            var validator = new WorldDataValidator();
+
+            var result = validator.Validate(world);
+
+            Assert.IsTrue(result.IsValid, string.Join(";", result.Errors));
+        }
+
+        [Test]
+        public void Validate_Fails_WhenSettlementReferencesMissingFaction()
+        {
+            var world = SampleWorldBuilder.CreateValidWorld();
+            world.Settlements[0].FactionId = "missing";
+            var validator = new WorldDataValidator();
+
+            var result = validator.Validate(world);
+
+            Assert.IsFalse(result.IsValid);
+            StringAssert.Contains("unknown faction", result.Errors[0]);
+        }
+
+        [Test]
+        public void Validate_Fails_ForDuplicateCharacterIds()
+        {
+            var world = SampleWorldBuilder.CreateValidWorld();
+            world.Characters.Add(world.Characters[0]);
+            var validator = new WorldDataValidator();
+
+            var result = validator.Validate(world);
+
+            Assert.IsFalse(result.IsValid);
+            StringAssert.Contains("Duplicate Character id", result.Errors[0]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add core world data containers with normalization and validation support
- implement JSON serialization seam for deterministic world snapshots
- wire deterministic services through a scriptable installer and bootstrapper with EditMode coverage

## Testing
- not run (Unity Test Framework not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dca989a6ac8329a5c5c7a80c461a8f