### PR TITLE
Add deterministic overworld generation, simulation loop, and persistence gateway

### DIFF
--- a/Assets/_Project/Scripts/Generation/OverworldGenerationPipeline.cs
+++ b/Assets/_Project/Scripts/Generation/OverworldGenerationPipeline.cs
@@ -1,0 +1,531 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Wastelands.Core.Data;
+using Wastelands.Core.Services;
+
+namespace Wastelands.Generation
+{
+    public readonly struct OverworldGenerationConfig
+    {
+        public OverworldGenerationConfig(ulong seed, int width, int height, ApocalypseType apocalypse)
+        {
+            if (width <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(width));
+            }
+
+            if (height <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(height));
+            }
+
+            Seed = seed;
+            Width = width;
+            Height = height;
+            Apocalypse = apocalypse;
+        }
+
+        public ulong Seed { get; }
+        public int Width { get; }
+        public int Height { get; }
+        public ApocalypseType Apocalypse { get; }
+    }
+
+    public interface IOverworldGenerationPipeline
+    {
+        WorldData Generate(OverworldGenerationConfig config);
+    }
+
+    /// <summary>
+    /// Deterministic overworld generation pipeline that follows the steps outlined in docs/WORLDGEN.md.
+    /// </summary>
+    public sealed class OverworldGenerationPipeline : IOverworldGenerationPipeline
+    {
+        private const string HeightmapChannel = "worldgen.heightmap";
+        private const string ClimateChannel = "worldgen.climate";
+        private const string BiomeChannel = "worldgen.biomes";
+        private const string HazardChannel = "worldgen.hazards";
+        private const string ResourceChannel = "worldgen.resources";
+        private const int DefaultFactionCount = 3;
+
+        private readonly IRngService _rngService;
+
+        public OverworldGenerationPipeline(IRngService rngService)
+        {
+            _rngService = rngService ?? throw new ArgumentNullException(nameof(rngService));
+        }
+
+        public WorldData Generate(OverworldGenerationConfig config)
+        {
+            var world = new WorldData
+            {
+                Seed = config.Seed,
+                Apocalypse = new ApocalypseMeta
+                {
+                    Type = config.Apocalypse,
+                    Severity = 0.5f,
+                }
+            };
+
+            var tiles = GenerateTiles(config);
+            world.Tiles = tiles;
+
+            PopulateApocalypseMetadata(world, config, tiles);
+
+            var factions = SeedFactions(world, config, tiles);
+            world.Factions = factions;
+
+            var settlements = CreateSettlements(tiles, factions);
+            world.Settlements = settlements;
+
+            var characters = CreateLeaders(factions);
+            world.Characters = characters;
+
+            HookupFactionReferences(factions, settlements, characters);
+
+            world.Events = CreateInitialEvents(world);
+            world.Legends = CreateInitialLegends(world.Events);
+            world.OracleState = CreateOracleState();
+            world.BaseState = CreateBaseState(settlements, characters, world);
+
+            WorldDataNormalizer.Normalize(world);
+            return world;
+        }
+
+        private List<Tile> GenerateTiles(OverworldGenerationConfig config)
+        {
+            var tiles = new List<Tile>(config.Width * config.Height);
+            var heightRng = _rngService.GetChannel(HeightmapChannel);
+            var climateRng = _rngService.GetChannel(ClimateChannel);
+            var biomeRng = _rngService.GetChannel(BiomeChannel);
+            var hazardRng = _rngService.GetChannel(HazardChannel);
+            var resourceRng = _rngService.GetChannel(ResourceChannel);
+
+            for (var y = 0; y < config.Height; y++)
+            {
+                for (var x = 0; x < config.Width; x++)
+                {
+                    var tileId = $"tile_{x}_{y}";
+                    var height = SampleSigned(heightRng, config.Seed, x, y, 11);
+                    var latitude = (float)y / Math.Max(1, config.Height - 1);
+                    var temperatureBase = 1f - (float)Math.Abs(latitude - 0.5f) * 2f; // equator warmer
+                    var temperatureNoise = (float)(Sample(heightRng, config.Seed, x, y, 29) * 0.35f);
+                    var temperature = Clamp01(temperatureBase + temperatureNoise);
+
+                    var moisture = Clamp01((float)Sample(climateRng, config.Seed, x, y, 7));
+                    var biome = SelectBiome(height, temperature, moisture, biomeRng, config.Seed, x, y);
+                    var hazards = DetermineHazards(config.Apocalypse, hazardRng, config.Seed, x, y, temperature, biome);
+                    var resources = DetermineResources(resourceRng, config.Seed, x, y, biome);
+
+                    var tile = new Tile
+                    {
+                        Id = tileId,
+                        Position = new Int2(x, y),
+                        Height = height,
+                        Temperature = temperature,
+                        Moisture = moisture,
+                        BiomeId = biome,
+                        HazardTags = hazards,
+                    };
+
+                    if (resources.Count > 0)
+                    {
+                        tile.HazardTags.AddRange(resources);
+                    }
+
+                    tiles.Add(tile);
+                }
+            }
+
+            return tiles;
+        }
+
+        private static float SampleSigned(IRngChannel channel, ulong seed, int x, int y, int salt)
+        {
+            var value = Sample(channel, seed, x, y, salt);
+            return (float)(value * 2d - 1d);
+        }
+
+        private static double Sample(IRngChannel channel, ulong seed, int x, int y, int salt)
+        {
+            channel.Reseed(DeriveOffset(seed, x, y, salt));
+            return channel.NextDouble();
+        }
+
+        private static int DeriveOffset(ulong seed, int x, int y, int salt)
+        {
+            unchecked
+            {
+                var lower = (int)(seed & 0xFFFFFFFF);
+                var upper = (int)((seed >> 32) & 0xFFFFFFFF);
+                return HashCode.Combine(lower, upper, x, y, salt);
+            }
+        }
+
+        private static string SelectBiome(float height, float temperature, float moisture, IRngChannel channel, ulong seed, int x, int y)
+        {
+            if (height < -0.1f)
+            {
+                return "biome_sunken_basin";
+            }
+
+            if (height > 0.6f)
+            {
+                return temperature > 0.5f ? "biome_crimson_mesa" : "biome_frozen_peak";
+            }
+
+            if (moisture < 0.25f)
+            {
+                return temperature > 0.6f ? "biome_glass_desert" : "biome_shattered_steppe";
+            }
+
+            if (moisture > 0.75f)
+            {
+                return temperature > 0.5f ? "biome_fungal_forest" : "biome_rust_mire";
+            }
+
+            var roll = Sample(channel, seed, x, y, 53);
+            return roll > 0.5d ? "biome_ashen_plains" : "biome_marrow_fields";
+        }
+
+        private static List<string> DetermineHazards(ApocalypseType apocalypse, IRngChannel channel, ulong seed, int x, int y, float temperature, string biome)
+        {
+            var hazards = new List<string>();
+            var severityRoll = Sample(channel, seed, x, y, 71);
+            if (severityRoll > 0.7d)
+            {
+                hazards.Add(apocalypse switch
+                {
+                    ApocalypseType.RadiantStorm => "haz_radiant_flux",
+                    ApocalypseType.NanoPlague => "haz_nanite_bloom",
+                    ApocalypseType.ArcaneSundering => "haz_void_rupture",
+                    ApocalypseType.VoidBlight => "haz_hollow_winds",
+                    _ => "haz_unknown"
+                });
+            }
+
+            if (temperature > 0.8f && !hazards.Contains("haz_radiant_flux"))
+            {
+                hazards.Add("haz_solar_scorch");
+            }
+
+            if (biome == "biome_fungal_forest" && !hazards.Contains("haz_sporefall"))
+            {
+                hazards.Add("haz_sporefall");
+            }
+
+            return hazards;
+        }
+
+        private static List<string> DetermineResources(IRngChannel channel, ulong seed, int x, int y, string biome)
+        {
+            var list = new List<string>();
+            var roll = Sample(channel, seed, x, y, 83);
+            if (roll > 0.85d)
+            {
+                list.Add("res_relic_cache");
+            }
+            else if (roll > 0.55d)
+            {
+                list.Add(biome switch
+                {
+                    "biome_glass_desert" => "res_silica_vein",
+                    "biome_fungal_forest" => "res_myco_spores",
+                    "biome_crimson_mesa" => "res_iron_spine",
+                    _ => "res_salvage_field"
+                });
+            }
+
+            return list;
+        }
+
+        private static void PopulateApocalypseMetadata(WorldData world, OverworldGenerationConfig config, IReadOnlyList<Tile> tiles)
+        {
+            var centerTile = tiles.OrderBy(t => DistanceToCenter(t.Position, config)).First();
+            world.Apocalypse.OriginTileId = centerTile.Id;
+            world.Apocalypse.EraTimeline = new List<EraEvent>
+            {
+                new() { Timestamp = 0, Description = "Pre-Fall prosperity" },
+                new() { Timestamp = 1, Description = "Cataclysm reshapes the wastes" },
+                new() { Timestamp = 2, Description = "Factions fracture into splinters" },
+                new() { Timestamp = 3, Description = "Present day conflicts ignite" }
+            };
+        }
+
+        private static double DistanceToCenter(Int2 position, OverworldGenerationConfig config)
+        {
+            var centerX = (config.Width - 1) / 2.0;
+            var centerY = (config.Height - 1) / 2.0;
+            var dx = position.X - centerX;
+            var dy = position.Y - centerY;
+            return Math.Sqrt(dx * dx + dy * dy);
+        }
+
+        private List<Faction> SeedFactions(WorldData world, OverworldGenerationConfig config, IReadOnlyList<Tile> tiles)
+        {
+            var viableTiles = tiles
+                .Where(t => t.HazardTags.All(tag => !tag.StartsWith("haz_", StringComparison.Ordinal) || tag == "haz_sporefall"))
+                .OrderBy(t => DistanceToCenter(t.Position, config))
+                .Take(DefaultFactionCount)
+                .ToList();
+
+            var channel = _rngService.GetChannel("worldgen.factions");
+
+            var archetypes = Enum.GetValues(typeof(FactionArchetype)).Cast<FactionArchetype>().ToArray();
+            var factions = new List<Faction>();
+            for (var index = 0; index < viableTiles.Count; index++)
+            {
+                var tile = viableTiles[index];
+                channel.Reseed(DeriveOffset(world.Seed, tile.Position.X, tile.Position.Y, 97));
+                var archetype = archetypes[channel.NextInt(0, archetypes.Length)];
+
+                var faction = new Faction
+                {
+                    Id = $"fac_{index:D2}",
+                    Name = GenerateFactionName(channel, world.Seed, tile.Position),
+                    Archetype = archetype,
+                    EthosProfile = new EthosProfile
+                    {
+                        Compassion = (float)Sample(channel, world.Seed, tile.Position.X, tile.Position.Y, 101),
+                        Ruthlessness = (float)Sample(channel, world.Seed, tile.Position.X, tile.Position.Y, 103),
+                        Tradition = (float)Sample(channel, world.Seed, tile.Position.X, tile.Position.Y, 107),
+                        Innovation = (float)Sample(channel, world.Seed, tile.Position.X, tile.Position.Y, 109)
+                    },
+                    Relations = new List<RelationRecord>(),
+                    NobleRoster = new List<NobleRoleAssignment>(),
+                    Holdings = new List<string>()
+                };
+
+                factions.Add(faction);
+            }
+
+            foreach (var faction in factions)
+            {
+                foreach (var other in factions)
+                {
+                    if (ReferenceEquals(faction, other))
+                    {
+                        continue;
+                    }
+
+                    var relationStrength = 0.25f + 0.5f * (float)Sample(channel, world.Seed, faction.Id.GetHashCode(), other.Id.GetHashCode(), 113);
+                    faction.Relations.Add(new RelationRecord
+                    {
+                        TargetFactionId = other.Id,
+                        Standing = relationStrength,
+                        State = relationStrength > 0.6f ? RelationState.Allied : relationStrength < 0.35f ? RelationState.Hostile : RelationState.Neutral
+                    });
+                }
+            }
+
+            return factions;
+        }
+
+        private static string GenerateFactionName(IRngChannel channel, ulong seed, Int2 position)
+        {
+            var prefixes = new[] { "Dust", "Iron", "Solar", "Echo", "Shard" };
+            var suffixes = new[] { "Walkers", "Legion", "Covenant", "Collective", "Syndicate" };
+            channel.Reseed(DeriveOffset(seed, position.X, position.Y, 131));
+            var prefix = prefixes[channel.NextInt(0, prefixes.Length)];
+            var suffix = suffixes[channel.NextInt(0, suffixes.Length)];
+            return $"{prefix} {suffix}";
+        }
+
+        private static List<Settlement> CreateSettlements(IEnumerable<Tile> tiles, IReadOnlyList<Faction> factions)
+        {
+            var settlements = new List<Settlement>();
+            var paired = tiles.Zip(factions, (tile, faction) => (tile, faction)).ToList();
+            foreach (var (tile, faction) in paired)
+            {
+                var settlement = new Settlement
+                {
+                    Id = $"set_{tile.Position.X}_{tile.Position.Y}",
+                    FactionId = faction.Id,
+                    TileId = tile.Id,
+                    Population = 150 + tile.Position.X * 5 + tile.Position.Y * 3,
+                    Economy = new EconomyProfile
+                    {
+                        Production = Clamp(tile.Height + 1f, 0f, 2f),
+                        Trade = Clamp(tile.Moisture + 0.5f, 0f, 2f),
+                        Research = Clamp(tile.Temperature + 0.3f, 0f, 2f)
+                    },
+                    DefenseRating = 0.4f + tile.Height * 0.3f
+                };
+
+                settlements.Add(settlement);
+            }
+
+            return settlements;
+        }
+
+        private static List<Character> CreateLeaders(IReadOnlyList<Faction> factions)
+        {
+            var characters = new List<Character>();
+            foreach (var faction in factions)
+            {
+                var character = new Character
+                {
+                    Id = $"char_{faction.Id}",
+                    Name = $"{faction.Name} Primus",
+                    FactionId = faction.Id,
+                    Traits = new List<TraitId> { TraitId.Visionary },
+                    Skills = new Dictionary<SkillId, SkillLevel>
+                    {
+                        { SkillId.Leadership, new() { Level = 4, Experience = 25, Aptitude = 1.2f } },
+                        { SkillId.Tactics, new() { Level = 3, Experience = 18, Aptitude = 1.05f } }
+                    },
+                    Relationships = new List<RelationshipRecord>(),
+                    CurrentRole = NobleRole.Overseer,
+                    Status = CharacterStatus.Active
+                };
+
+                characters.Add(character);
+            }
+
+            return characters;
+        }
+
+        private static void HookupFactionReferences(IEnumerable<Faction> factions, IEnumerable<Settlement> settlements, IEnumerable<Character> characters)
+        {
+            var characterLookup = characters.ToDictionary(c => c.FactionId, c => c, StringComparer.Ordinal);
+            foreach (var faction in factions)
+            {
+                if (characterLookup.TryGetValue(faction.Id, out var leader))
+                {
+                    faction.NobleRoster.Add(new NobleRoleAssignment { CharacterId = leader.Id, Role = NobleRole.Overseer });
+                }
+
+                foreach (var settlement in settlements.Where(s => s.FactionId == faction.Id))
+                {
+                    faction.Holdings.Add(settlement.Id);
+                }
+            }
+        }
+
+        private static List<EventRecord> CreateInitialEvents(WorldData world)
+        {
+            return new List<EventRecord>
+            {
+                new()
+                {
+                    Id = "event_foundation",
+                    Timestamp = 0,
+                    EventType = EventType.Discovery,
+                    Actors = world.Characters.Select(c => c.Id).ToList(),
+                    LocationId = world.Settlements.First().Id,
+                    Details = new Dictionary<string, string>
+                    {
+                        { "message", "Settlements established after the Cataclysm" }
+                    }
+                }
+            };
+        }
+
+        private static List<LegendEntry> CreateInitialLegends(IEnumerable<EventRecord> events)
+        {
+            return new List<LegendEntry>
+            {
+                new()
+                {
+                    Id = "legend_reclamation",
+                    Summary = "The surviving houses carve footholds into the wastes.",
+                    EventIds = events.Select(e => e.Id).ToList()
+                }
+            };
+        }
+
+        private static OracleState CreateOracleState()
+        {
+            return new OracleState
+            {
+                ActiveDeckId = "deck_minor_intro",
+                TensionScore = 0.35f,
+                Cooldowns = new Dictionary<string, long>(),
+                AvailableDecks = new List<EventDeck>
+                {
+                    new()
+                    {
+                        Id = "deck_minor_intro",
+                        Tier = OracleDeckTier.Minor,
+                        Weight = 1f,
+                        Cards = new List<EventCard>
+                        {
+                            new()
+                            {
+                                Id = "card_supply_cache",
+                                Narrative = "A cache of pre-fall supplies appears in the wastes.",
+                                Effects = new List<EventEffect>
+                                {
+                                    new()
+                                    {
+                                        EffectType = "spawn_cache",
+                                        Parameters = new Dictionary<string, string>
+                                        {
+                                            { "rarity", "uncommon" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        private static BaseState CreateBaseState(IReadOnlyList<Settlement> settlements, IReadOnlyList<Character> characters, WorldData world)
+        {
+            var anchorSettlement = settlements.FirstOrDefault();
+            var leader = characters.FirstOrDefault();
+            return new BaseState
+            {
+                Active = false,
+                SiteTileId = anchorSettlement?.TileId ?? world.Tiles.First().Id,
+                Zones = new List<BaseZone>
+                {
+                    new()
+                    {
+                        Id = "zone_command",
+                        Name = "Command Nexus",
+                        Type = ZoneType.Watchtower,
+                        Efficiency = 0.85f
+                    }
+                },
+                Population = leader != null ? new List<string> { leader.Id } : new List<string>(),
+                Infrastructure = new Dictionary<string, float>
+                {
+                    { "power", 0.75f },
+                    { "water", 0.65f }
+                },
+                Inventory = new List<ItemStack>
+                {
+                    new() { ItemId = "supply_basic", Quantity = 25 }
+                },
+                AlertLevel = AlertLevel.Calm,
+                Research = new ResearchState
+                {
+                    CompletedProjects = new List<string>(),
+                    ActiveProjectId = string.Empty,
+                    ActiveProgress = 0f
+                }
+            };
+        }
+
+        private static float Clamp(float value, float min, float max)
+        {
+            if (value < min)
+            {
+                return min;
+            }
+
+            if (value > max)
+            {
+                return max;
+            }
+
+            return value;
+        }
+
+        private static float Clamp01(float value) => Clamp(value, 0f, 1f);
+    }
+}

--- a/Assets/_Project/Scripts/Generation/OverworldGenerationPipeline.cs.meta
+++ b/Assets/_Project/Scripts/Generation/OverworldGenerationPipeline.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cb073bec90fc41aeb31c3f44372ee082
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/Persistence/OverworldSnapshotGateway.cs
+++ b/Assets/_Project/Scripts/Persistence/OverworldSnapshotGateway.cs
@@ -1,0 +1,85 @@
+using System;
+using System.IO;
+using Wastelands.Core.Data;
+
+namespace Wastelands.Persistence
+{
+    public interface IOverworldSnapshotGateway
+    {
+        string SaveToString(WorldData world);
+        void SaveToStream(WorldData world, Stream destination);
+        void SaveToFile(WorldData world, string filePath);
+        WorldData LoadFromString(string json);
+        WorldData LoadFromStream(Stream source);
+        WorldData LoadFromFile(string filePath);
+    }
+
+    /// <summary>
+    /// Entry point for persisting overworld snapshots through <see cref="WorldDataSerializer"/>.
+    /// </summary>
+    public sealed class OverworldSnapshotGateway : IOverworldSnapshotGateway
+    {
+        private readonly IWorldDataSerializer _serializer;
+
+        public OverworldSnapshotGateway(IWorldDataSerializer serializer)
+        {
+            _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+        }
+
+        public string SaveToString(WorldData world)
+        {
+            return _serializer.Serialize(world);
+        }
+
+        public void SaveToStream(WorldData world, Stream destination)
+        {
+            if (destination == null)
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
+
+            _serializer.SerializeToStream(world, destination);
+            if (destination.CanSeek)
+            {
+                destination.Seek(0, SeekOrigin.Begin);
+            }
+        }
+
+        public void SaveToFile(WorldData world, string filePath)
+        {
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                throw new ArgumentException("File path must be provided.", nameof(filePath));
+            }
+
+            using var file = File.Create(filePath);
+            SaveToStream(world, file);
+        }
+
+        public WorldData LoadFromString(string json)
+        {
+            return _serializer.Deserialize(json);
+        }
+
+        public WorldData LoadFromStream(Stream source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            return _serializer.DeserializeFromStream(source);
+        }
+
+        public WorldData LoadFromFile(string filePath)
+        {
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                throw new ArgumentException("File path must be provided.", nameof(filePath));
+            }
+
+            using var file = File.OpenRead(filePath);
+            return LoadFromStream(file);
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Persistence/OverworldSnapshotGateway.cs.meta
+++ b/Assets/_Project/Scripts/Persistence/OverworldSnapshotGateway.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8d858784d4f4314b27f8c895a746af7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/Simulation/OverworldSimulationLoop.cs
+++ b/Assets/_Project/Scripts/Simulation/OverworldSimulationLoop.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Wastelands.Core.Data;
+using Wastelands.Core.Management;
+using Wastelands.Core.Services;
+
+namespace Wastelands.Simulation
+{
+    public readonly struct OverworldTickContext
+    {
+        private readonly TickContext _tickContext;
+        private readonly IRngService _rngService;
+
+        internal OverworldTickContext(WorldData world, TickContext tickContext, IRngService rngService)
+        {
+            World = world ?? throw new ArgumentNullException(nameof(world));
+            _tickContext = tickContext;
+            _rngService = rngService ?? throw new ArgumentNullException(nameof(rngService));
+        }
+
+        public long Tick => _tickContext.Tick;
+        public WorldData World { get; }
+        public ITimeProvider TimeProvider => _tickContext.TimeProvider;
+        public IEventBus EventBus => _tickContext.EventBus;
+
+        public IRngChannel GetChannel(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("Channel name must be provided.", nameof(name));
+            }
+
+            var channel = _rngService.GetChannel($"simulation.{name}");
+            channel.Reseed(DeriveOffset(name));
+            return channel;
+        }
+
+        private int DeriveOffset(string name)
+        {
+            unchecked
+            {
+                var seedLow = (int)(World.Seed & 0xFFFFFFFF);
+                var tickLow = (int)(Tick & 0xFFFFFFFF);
+                var nameHash = StringComparer.Ordinal.GetHashCode(name);
+                return HashCode.Combine(seedLow, tickLow, nameHash);
+            }
+        }
+    }
+
+    public interface IOverworldSimulationPhase
+    {
+        string Name { get; }
+        void Execute(in OverworldTickContext context);
+    }
+
+    public sealed class OverworldSimulationLoop : ITickSystem
+    {
+        private readonly WorldData _world;
+        private readonly List<IOverworldSimulationPhase> _phases;
+        private readonly IRngService _rngService;
+
+        public OverworldSimulationLoop(WorldData world, IEnumerable<IOverworldSimulationPhase> phases, IRngService rngService)
+        {
+            _world = world ?? throw new ArgumentNullException(nameof(world));
+            _rngService = rngService ?? throw new ArgumentNullException(nameof(rngService));
+
+            if (phases == null)
+            {
+                throw new ArgumentNullException(nameof(phases));
+            }
+
+            _phases = phases.ToList();
+            if (_phases.Count == 0)
+            {
+                throw new ArgumentException("At least one simulation phase must be provided.", nameof(phases));
+            }
+        }
+
+        public IReadOnlyList<IOverworldSimulationPhase> Phases => _phases;
+
+        public void Tick(in TickContext context)
+        {
+            var overworldContext = new OverworldTickContext(_world, context, _rngService);
+            foreach (var phase in _phases)
+            {
+                phase.Execute(overworldContext);
+            }
+
+            WorldDataNormalizer.Normalize(_world);
+            context.EventBus.Publish(new OverworldTickCompleted(overworldContext.Tick));
+        }
+    }
+
+    public readonly struct OverworldTickCompleted
+    {
+        public OverworldTickCompleted(long tick)
+        {
+            Tick = tick;
+        }
+
+        public long Tick { get; }
+    }
+}

--- a/Assets/_Project/Scripts/Simulation/OverworldSimulationLoop.cs.meta
+++ b/Assets/_Project/Scripts/Simulation/OverworldSimulationLoop.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7ab71e9a2fc14b019f857f0eb2785bde
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/Simulation/Phases.meta
+++ b/Assets/_Project/Scripts/Simulation/Phases.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e7e1c57e917a4ec58af45baf49b0864b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/Simulation/Phases/OverworldSimulationPhases.cs
+++ b/Assets/_Project/Scripts/Simulation/Phases/OverworldSimulationPhases.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Wastelands.Core.Data;
+
+namespace Wastelands.Simulation.Phases
+{
+    internal static class PhaseMath
+    {
+        public static float Clamp01(float value)
+        {
+            if (value < 0f)
+            {
+                return 0f;
+            }
+
+            if (value > 1f)
+            {
+                return 1f;
+            }
+
+            return value;
+        }
+    }
+
+    public sealed class HazardPropagationPhase : IOverworldSimulationPhase
+    {
+        public string Name => "hazards";
+
+        public void Execute(in OverworldTickContext context)
+        {
+            var channel = context.GetChannel(Name);
+            var severityDelta = (float)(channel.NextDouble() * 0.06d - 0.03d);
+            context.World.Apocalypse.Severity = PhaseMath.Clamp01(context.World.Apocalypse.Severity + severityDelta);
+
+            if (context.World.Apocalypse.Severity < 0.6f)
+            {
+                return;
+            }
+
+            foreach (var tile in context.World.Tiles)
+            {
+                if (tile.Temperature > 0.7f && !tile.HazardTags.Contains("haz_scorch_wave"))
+                {
+                    tile.HazardTags.Add("haz_scorch_wave");
+                }
+            }
+        }
+    }
+
+    public sealed class FactionDiplomacyPhase : IOverworldSimulationPhase
+    {
+        public string Name => "diplomacy";
+
+        public void Execute(in OverworldTickContext context)
+        {
+            foreach (var faction in context.World.Factions)
+            {
+                foreach (var relation in faction.Relations)
+                {
+                    var channel = context.GetChannel($"{Name}.{faction.Id}.{relation.TargetFactionId}");
+                    var delta = (float)(channel.NextDouble() * 0.1d - 0.05d);
+                    relation.Standing = PhaseMath.Clamp01(relation.Standing + delta);
+                    relation.State = relation.Standing switch
+                    {
+                        > 0.65f => RelationState.Allied,
+                        < 0.35f => RelationState.Hostile,
+                        _ => RelationState.Neutral
+                    };
+                }
+            }
+        }
+    }
+
+    public sealed class SettlementLogisticsPhase : IOverworldSimulationPhase
+    {
+        public string Name => "logistics";
+
+        public void Execute(in OverworldTickContext context)
+        {
+            foreach (var settlement in context.World.Settlements)
+            {
+                var channel = context.GetChannel($"{Name}.{settlement.Id}");
+                var productionDelta = (float)(channel.NextDouble() * 0.08d - 0.04d);
+                var tradeDelta = (float)(channel.NextDouble() * 0.06d - 0.03d);
+                var researchDelta = (float)(channel.NextDouble() * 0.05d - 0.025d);
+
+                settlement.Economy = new EconomyProfile
+                {
+                    Production = ClampToRange(settlement.Economy.Production + productionDelta, 0f, 3f),
+                    Trade = ClampToRange(settlement.Economy.Trade + tradeDelta, 0f, 3f),
+                    Research = ClampToRange(settlement.Economy.Research + researchDelta, 0f, 3f)
+                };
+
+                settlement.DefenseRating = ClampToRange(settlement.DefenseRating + productionDelta * 0.25f, 0f, 5f);
+            }
+        }
+
+        private static float ClampToRange(float value, float min, float max)
+        {
+            if (value < min)
+            {
+                return min;
+            }
+
+            if (value > max)
+            {
+                return max;
+            }
+
+            return value;
+        }
+    }
+
+    public sealed class OracleReviewPhase : IOverworldSimulationPhase
+    {
+        public string Name => "oracle";
+
+        public void Execute(in OverworldTickContext context)
+        {
+            var channel = context.GetChannel(Name);
+            var tensionDelta = (float)(channel.NextDouble() * 0.08d - 0.04d);
+            var severityInfluence = (context.World.Apocalypse.Severity - 0.5f) * 0.1f;
+            var newTension = PhaseMath.Clamp01(context.World.OracleState.TensionScore + tensionDelta + severityInfluence);
+            context.World.OracleState.TensionScore = newTension;
+
+            var cooldownKeys = context.World.OracleState.Cooldowns.Keys.ToList();
+            foreach (var key in cooldownKeys)
+            {
+                var value = context.World.OracleState.Cooldowns[key];
+                context.World.OracleState.Cooldowns[key] = Math.Max(0, value - 1);
+            }
+
+            var activeDeck = context.World.OracleState.AvailableDecks
+                .OrderByDescending(deck => deck.Tier)
+                .FirstOrDefault();
+
+            if (activeDeck != null && newTension > 0.6f)
+            {
+                context.World.OracleState.ActiveDeckId = activeDeck.Id;
+            }
+        }
+    }
+
+    public sealed class LegendCompilationPhase : IOverworldSimulationPhase
+    {
+        public string Name => "legends";
+
+        public void Execute(in OverworldTickContext context)
+        {
+            var world = context.World;
+            var eventId = $"event_tick_{context.Tick:D6}";
+            if (world.Events.Any(e => e.Id == eventId))
+            {
+                return;
+            }
+
+            var actorId = world.Characters.FirstOrDefault()?.Id;
+            var locationId = world.Settlements.FirstOrDefault()?.Id ?? world.BaseState.SiteTileId;
+
+            var record = new EventRecord
+            {
+                Id = eventId,
+                Timestamp = context.Tick,
+                EventType = EventType.Mandate,
+                Actors = string.IsNullOrEmpty(actorId) ? new List<string>() : new List<string> { actorId },
+                LocationId = locationId,
+                Details = new Dictionary<string, string>
+                {
+                    { "apocalypseSeverity", world.Apocalypse.Severity.ToString("0.00", CultureInfo.InvariantCulture) },
+                    { "tension", world.OracleState.TensionScore.ToString("0.00", CultureInfo.InvariantCulture) }
+                }
+            };
+
+            world.Events.Add(record);
+            world.Legends.Add(new LegendEntry
+            {
+                Id = $"legend_tick_{context.Tick:D6}",
+                Summary = $"Year {context.Tick}: factions adapt to the wastes.",
+                EventIds = new List<string> { record.Id }
+            });
+
+            context.EventBus.Publish(new OverworldLegendUpdated(record.Id));
+        }
+    }
+
+    public readonly struct OverworldLegendUpdated
+    {
+        public OverworldLegendUpdated(string eventId)
+        {
+            EventId = eventId ?? throw new ArgumentNullException(nameof(eventId));
+        }
+
+        public string EventId { get; }
+    }
+}

--- a/Assets/_Project/Scripts/Simulation/Phases/OverworldSimulationPhases.cs.meta
+++ b/Assets/_Project/Scripts/Simulation/Phases/OverworldSimulationPhases.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ff256bf46d504a95a98552668861ba98
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/EditMode/OverworldGenerationPipelineTests.cs
+++ b/Tests/EditMode/OverworldGenerationPipelineTests.cs
@@ -1,0 +1,39 @@
+using NUnit.Framework;
+using Wastelands.Core.Data;
+using Wastelands.Core.Services;
+using Wastelands.Generation;
+using Wastelands.Persistence;
+
+namespace Wastelands.Tests.EditMode
+{
+    public class OverworldGenerationPipelineTests
+    {
+        [Test]
+        public void Generate_ProducesDeterministicWorld()
+        {
+            var seed = 123456789UL;
+            var config = new OverworldGenerationConfig(seed, width: 6, height: 4, ApocalypseType.RadiantStorm);
+            var rngA = new DeterministicRngService(9001);
+            var rngB = new DeterministicRngService(9001);
+            var pipelineA = new OverworldGenerationPipeline(rngA);
+            var pipelineB = new OverworldGenerationPipeline(rngB);
+
+            var worldA = pipelineA.Generate(config);
+            var worldB = pipelineB.Generate(config);
+
+            Assert.That(worldA.Tiles, Has.Count.EqualTo(config.Width * config.Height));
+            Assert.That(worldA.Factions, Has.Count.GreaterThan(0));
+            Assert.That(worldA.Settlements, Has.Count.EqualTo(worldA.Factions.Count));
+
+            var serializer = new WorldDataSerializer();
+            var jsonA = serializer.Serialize(worldA);
+            var jsonB = serializer.Serialize(worldB);
+
+            Assert.AreEqual(jsonA, jsonB);
+
+            var validator = new WorldDataValidator();
+            var validation = validator.Validate(worldA);
+            Assert.That(validation.IsValid, Is.True, string.Join(",", validation.Errors));
+        }
+    }
+}

--- a/Tests/EditMode/OverworldGenerationPipelineTests.cs.meta
+++ b/Tests/EditMode/OverworldGenerationPipelineTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3e02be67f3ab47828b80d7784cf9aed5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/EditMode/OverworldSimulationLoopTests.cs
+++ b/Tests/EditMode/OverworldSimulationLoopTests.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Wastelands.Core.Data;
+using Wastelands.Core.Management;
+using Wastelands.Core.Services;
+using Wastelands.Persistence;
+using Wastelands.Simulation;
+using Wastelands.Simulation.Phases;
+
+namespace Wastelands.Tests.EditMode
+{
+    public class OverworldSimulationLoopTests
+    {
+        [Test]
+        public void Tick_RunsPhasesDeterministically()
+        {
+            var worldA = SampleWorldBuilder.CreateValidWorld();
+            var worldB = SampleWorldBuilder.CreateValidWorld();
+
+            var phasesA = CreatePhases();
+            var phasesB = CreatePhases();
+
+            var tracker = new List<long>();
+            var legendEvents = new List<string>();
+
+            RunSimulation(worldA, phasesA, tracker, legendEvents, ticks: 3);
+            Assert.That(tracker, Is.EqualTo(new[] { 1L, 2L, 3L }));
+            Assert.That(legendEvents, Has.Count.EqualTo(3));
+
+            RunSimulation(worldB, phasesB, ticks: 3);
+
+            var serializer = new WorldDataSerializer();
+            Assert.AreEqual(serializer.Serialize(worldA), serializer.Serialize(worldB));
+        }
+
+        private static IReadOnlyList<IOverworldSimulationPhase> CreatePhases()
+        {
+            return new IOverworldSimulationPhase[]
+            {
+                new HazardPropagationPhase(),
+                new FactionDiplomacyPhase(),
+                new SettlementLogisticsPhase(),
+                new OracleReviewPhase(),
+                new LegendCompilationPhase()
+            };
+        }
+
+        private static void RunSimulation(WorldData world, IReadOnlyList<IOverworldSimulationPhase> phases, int ticks)
+        {
+            RunSimulation(world, phases, null, null, ticks);
+        }
+
+        private static void RunSimulation(WorldData world, IReadOnlyList<IOverworldSimulationPhase> phases, List<long>? tickTracker, List<string>? legendEvents, int ticks)
+        {
+            var timeProvider = new ManualTimeProvider();
+            var rng = new DeterministicRngService(4242);
+            var eventBus = new EventBus();
+            var tickManager = new TickManager(timeProvider, rng, eventBus);
+            var loop = new OverworldSimulationLoop(world, phases, rng);
+            tickManager.RegisterSystem(loop);
+
+            if (tickTracker != null)
+            {
+                eventBus.Subscribe<OverworldTickCompleted>(evt => tickTracker.Add(evt.Tick));
+            }
+
+            if (legendEvents != null)
+            {
+                eventBus.Subscribe<OverworldLegendUpdated>(evt => legendEvents.Add(evt.EventId));
+            }
+
+            tickManager.Advance(ticks);
+        }
+    }
+}

--- a/Tests/EditMode/OverworldSimulationLoopTests.cs.meta
+++ b/Tests/EditMode/OverworldSimulationLoopTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 40bf45ecd9914155b76242d55d3089ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/EditMode/OverworldSnapshotGatewayTests.cs
+++ b/Tests/EditMode/OverworldSnapshotGatewayTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using Wastelands.Persistence;
+
+namespace Wastelands.Tests.EditMode
+{
+    public class OverworldSnapshotGatewayTests
+    {
+        [Test]
+        public void SaveAndLoadString_RoundTripsWorld()
+        {
+            var world = SampleWorldBuilder.CreateValidWorld();
+            var gateway = new OverworldSnapshotGateway(new WorldDataSerializer());
+
+            var json = gateway.SaveToString(world);
+            var loaded = gateway.LoadFromString(json);
+
+            var serializer = new WorldDataSerializer();
+            Assert.AreEqual(json, serializer.Serialize(loaded));
+        }
+
+        [Test]
+        public void SaveAndLoadStream_RoundTripsWorld()
+        {
+            var world = SampleWorldBuilder.CreateValidWorld();
+            var gateway = new OverworldSnapshotGateway(new WorldDataSerializer());
+
+            using var stream = new MemoryStream();
+            gateway.SaveToStream(world, stream);
+            var loaded = gateway.LoadFromStream(stream);
+
+            var serializer = new WorldDataSerializer();
+            Assert.AreEqual(serializer.Serialize(world), serializer.Serialize(loaded));
+        }
+
+        [Test]
+        public void SaveAndLoadFile_RoundTripsWorld()
+        {
+            var world = SampleWorldBuilder.CreateValidWorld();
+            var gateway = new OverworldSnapshotGateway(new WorldDataSerializer());
+
+            var path = Path.Combine(Path.GetTempPath(), $"wastelands_{Guid.NewGuid():N}.json");
+            try
+            {
+                gateway.SaveToFile(world, path);
+                var loaded = gateway.LoadFromFile(path);
+
+                var serializer = new WorldDataSerializer();
+                Assert.AreEqual(serializer.Serialize(world), serializer.Serialize(loaded));
+            }
+            finally
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+        }
+    }
+}

--- a/Tests/EditMode/OverworldSnapshotGatewayTests.cs.meta
+++ b/Tests/EditMode/OverworldSnapshotGatewayTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 71968b6d4e814847957f6d9fbf7c94f4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/EditMode/Wastelands.Tests.EditMode.asmdef
+++ b/Tests/EditMode/Wastelands.Tests.EditMode.asmdef
@@ -3,6 +3,8 @@
   "references": [
     "Wastelands.Core",
     "Wastelands.Persistence",
+    "Wastelands.Generation",
+    "Wastelands.Simulation",
     "Wastelands.UI",
     "UnityEngine.TestRunner",
     "UnityEditor.TestRunner"


### PR DESCRIPTION
## Summary
- implement an initial overworld generation pipeline that emits populated WorldData snapshots
- add a deterministic overworld simulation loop with modular tick phases and event publishing
- introduce persistence seams for overworld snapshots and cover the new systems with edit mode tests

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dcacc060f88329903d88e5982218d2