### PR TITLE
Add base mode bootstrap, simulation systems, and base state persistence diffs

### DIFF
--- a/Assets/_Project/Scripts/BaseMode/BaseModeSimulationLoop.cs
+++ b/Assets/_Project/Scripts/BaseMode/BaseModeSimulationLoop.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Wastelands.Core.Data;
+using Wastelands.Core.Management;
+using Wastelands.Core.Services;
+
+namespace Wastelands.BaseMode
+{
+    public readonly struct BaseModeTickContext
+    {
+        private readonly TickContext _tickContext;
+        private readonly IRngService _rngService;
+
+        internal BaseModeTickContext(WorldData world, BaseRuntimeState runtime, TickContext tickContext, IRngService rngService)
+        {
+            World = world ?? throw new ArgumentNullException(nameof(world));
+            Runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+            _tickContext = tickContext;
+            _rngService = rngService ?? throw new ArgumentNullException(nameof(rngService));
+        }
+
+        public long Tick => _tickContext.Tick;
+        public WorldData World { get; }
+        public BaseRuntimeState Runtime { get; }
+        public BaseState BaseState => Runtime.BaseState;
+        public ITimeProvider TimeProvider => _tickContext.TimeProvider;
+        public IEventBus EventBus => _tickContext.EventBus;
+        public int HoursPerDay => Runtime.HoursPerDay;
+
+        public IRngChannel GetChannel(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("Channel name must be provided.", nameof(name));
+            }
+
+            var channel = _rngService.GetChannel($"base.{name}");
+            channel.Reseed(DeriveOffset(name));
+            return channel;
+        }
+
+        private int DeriveOffset(string name)
+        {
+            unchecked
+            {
+                var seedLow = (int)(World.Seed & 0xFFFFFFFF);
+                var tickLow = (int)(Tick & 0xFFFFFFFF);
+                var nameHash = StringComparer.Ordinal.GetHashCode(name);
+                return HashCode.Combine(seedLow, tickLow, nameHash);
+            }
+        }
+    }
+
+    public interface IBaseModeSystem
+    {
+        string Name { get; }
+        void Execute(in BaseModeTickContext context);
+    }
+
+    public sealed class BaseModeSimulationLoop : ITickSystem
+    {
+        private readonly WorldData _world;
+        private readonly BaseRuntimeState _runtime;
+        private readonly List<IBaseModeSystem> _systems;
+        private readonly IRngService _rngService;
+
+        public BaseModeSimulationLoop(WorldData world, BaseRuntimeState runtime, IEnumerable<IBaseModeSystem> systems, IRngService rngService)
+        {
+            _world = world ?? throw new ArgumentNullException(nameof(world));
+            _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+            _rngService = rngService ?? throw new ArgumentNullException(nameof(rngService));
+
+            if (systems == null)
+            {
+                throw new ArgumentNullException(nameof(systems));
+            }
+
+            _systems = systems.ToList();
+            if (_systems.Count == 0)
+            {
+                throw new ArgumentException("At least one base mode system must be provided.", nameof(systems));
+            }
+        }
+
+        public IReadOnlyList<IBaseModeSystem> Systems => _systems;
+
+        public void Tick(in TickContext context)
+        {
+            if (!_runtime.BaseState.Active)
+            {
+                return;
+            }
+
+            var baseContext = new BaseModeTickContext(_world, _runtime, context, _rngService);
+            foreach (var system in _systems)
+            {
+                system.Execute(baseContext);
+            }
+
+            WorldDataNormalizer.Normalize(_world);
+            context.EventBus.Publish(new BaseModeTickCompleted(baseContext.Tick));
+        }
+    }
+
+    public readonly struct BaseModeTickCompleted
+    {
+        public BaseModeTickCompleted(long tick)
+        {
+            Tick = tick;
+        }
+
+        public long Tick { get; }
+    }
+}

--- a/Assets/_Project/Scripts/BaseMode/BaseRuntimeState.cs
+++ b/Assets/_Project/Scripts/BaseMode/BaseRuntimeState.cs
@@ -1,0 +1,482 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Wastelands.Core.Data;
+
+namespace Wastelands.BaseMode
+{
+    /// <summary>
+    /// Holds runtime-only data for the Base Mode simulation loop.
+    /// </summary>
+    public sealed class BaseRuntimeState
+    {
+        private readonly Dictionary<string, BaseZoneRuntime> _zonesById;
+        private readonly List<BaseJobResult> _recentlyCompletedJobs = new();
+
+        public BaseRuntimeState(WorldData world, BaseState baseState, int hoursPerDay)
+        {
+            World = world ?? throw new ArgumentNullException(nameof(world));
+            BaseState = baseState ?? throw new ArgumentNullException(nameof(baseState));
+            if (hoursPerDay <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(hoursPerDay));
+            }
+
+            HoursPerDay = hoursPerDay;
+            _zonesById = baseState.Zones
+                .ToDictionary(zone => zone.Id, zone => new BaseZoneRuntime(zone), StringComparer.Ordinal);
+            JobBoard = new BaseJobBoard();
+            RaidThreat = new RaidThreatState();
+            MandateTracker = new MandateTracker(hoursPerDay);
+        }
+
+        public WorldData World { get; }
+        public BaseState BaseState { get; }
+        public int HoursPerDay { get; }
+        public BaseJobBoard JobBoard { get; }
+        public RaidThreatState RaidThreat { get; }
+        public MandateTracker MandateTracker { get; }
+        public List<BaseJobResult> RecentlyCompletedJobs => _recentlyCompletedJobs;
+
+        public IReadOnlyDictionary<string, BaseZoneRuntime> Zones => _zonesById;
+
+        public IEnumerable<BaseZoneRuntime> EnumerateZones() => _zonesById.Values;
+
+        public bool TryGetZoneRuntime(string zoneId, out BaseZoneRuntime runtime)
+        {
+            return _zonesById.TryGetValue(zoneId, out runtime!);
+        }
+
+        public void SeedInitialJobs()
+        {
+            JobBoard.SeedFromBaseState(BaseState, EnumerateZones());
+        }
+
+        public void SeedInitialMandates(WorldData world)
+        {
+            MandateTracker.Initialize(world, BaseState);
+        }
+
+        public void RecordCompletedJobs(IEnumerable<BaseJobResult> jobs)
+        {
+            _recentlyCompletedJobs.Clear();
+            _recentlyCompletedJobs.AddRange(jobs);
+        }
+    }
+
+    public sealed class BaseZoneRuntime
+    {
+        public BaseZoneRuntime(BaseZone zone)
+        {
+            Zone = zone ?? throw new ArgumentNullException(nameof(zone));
+            MoraleModifier = 0.5f;
+            Wear = 0.1f;
+            WorkforceAllocation = 1f;
+        }
+
+        public BaseZone Zone { get; }
+        public float MoraleModifier { get; set; }
+        public float Wear { get; set; }
+        public float WorkforceAllocation { get; set; }
+    }
+
+    public sealed class BaseJobBoard
+    {
+        private readonly List<BaseJob> _jobs = new();
+
+        public IReadOnlyList<BaseJob> Jobs => _jobs;
+
+        public void SeedFromBaseState(BaseState state, IEnumerable<BaseZoneRuntime> zones)
+        {
+            if (state == null)
+            {
+                throw new ArgumentNullException(nameof(state));
+            }
+
+            if (zones == null)
+            {
+                throw new ArgumentNullException(nameof(zones));
+            }
+
+            _jobs.Clear();
+
+            foreach (var zone in zones)
+            {
+                var job = CreateZoneJob(state, zone.Zone);
+                if (job != null)
+                {
+                    _jobs.Add(job);
+                }
+            }
+
+            if (!string.IsNullOrEmpty(state.Research.ActiveProjectId))
+            {
+                _jobs.Add(new BaseJob
+                {
+                    Id = $"job_research_{state.Research.ActiveProjectId}",
+                    Type = BaseJobType.Research,
+                    Priority = BaseJobPriority.High,
+                    ZoneId = state.Zones.FirstOrDefault(z => z.Type == ZoneType.ResearchLab)?.Id,
+                    DurationHours = 6,
+                    RemainingHours = 6,
+                    Repeatable = true
+                });
+            }
+
+            if (state.Population.Count > 0)
+            {
+                _jobs.Add(new BaseJob
+                {
+                    Id = "job_patrol_default",
+                    Type = BaseJobType.Patrol,
+                    Priority = BaseJobPriority.Normal,
+                    ZoneId = state.Zones.FirstOrDefault(z => z.Type == ZoneType.Watchtower)?.Id,
+                    DurationHours = 8,
+                    RemainingHours = 8,
+                    Repeatable = true
+                });
+            }
+        }
+
+        public void Enqueue(BaseJob job)
+        {
+            if (job == null)
+            {
+                throw new ArgumentNullException(nameof(job));
+            }
+
+            if (_jobs.Any(existing => string.Equals(existing.Id, job.Id, StringComparison.Ordinal)))
+            {
+                return;
+            }
+
+            job.RemainingHours = job.DurationHours;
+            _jobs.Add(job);
+        }
+
+        public void Advance(in BaseModeTickContext context, ICollection<BaseJobResult> completed)
+        {
+            if (completed == null)
+            {
+                throw new ArgumentNullException(nameof(completed));
+            }
+
+            if (_jobs.Count == 0)
+            {
+                return;
+            }
+
+            var workforce = Math.Max(1, context.BaseState.Population.Count);
+            var ordered = _jobs
+                .OrderByDescending(job => job.Priority)
+                .ThenBy(job => job.Id, StringComparer.Ordinal)
+                .ToList();
+
+            var processed = 0;
+            foreach (var job in ordered)
+            {
+                if (processed >= workforce)
+                {
+                    break;
+                }
+
+                job.RemainingHours--;
+                processed++;
+
+                if (job.RemainingHours > 0)
+                {
+                    continue;
+                }
+
+                completed.Add(new BaseJobResult(job.Id, job.Type, job.ZoneId, job.Priority, job.DurationHours));
+
+                if (job.Repeatable)
+                {
+                    job.RemainingHours = job.DurationHours;
+                }
+                else
+                {
+                    _jobs.Remove(job);
+                }
+            }
+        }
+
+        private static BaseJob? CreateZoneJob(BaseState state, BaseZone zone)
+        {
+            var priority = zone.Type switch
+            {
+                ZoneType.Watchtower => BaseJobPriority.High,
+                ZoneType.Workshop => BaseJobPriority.Normal,
+                ZoneType.ResearchLab => BaseJobPriority.High,
+                ZoneType.Farm => BaseJobPriority.Normal,
+                _ => BaseJobPriority.Low
+            };
+
+            var type = zone.Type switch
+            {
+                ZoneType.Habitat => BaseJobType.Maintenance,
+                ZoneType.Workshop => BaseJobType.Production,
+                ZoneType.Farm => BaseJobType.Production,
+                ZoneType.Watchtower => BaseJobType.Patrol,
+                ZoneType.ResearchLab => BaseJobType.Research,
+                _ => BaseJobType.Maintenance
+            };
+
+            var duration = zone.Type switch
+            {
+                ZoneType.Farm => 10,
+                ZoneType.Workshop => 8,
+                ZoneType.Watchtower => 8,
+                ZoneType.ResearchLab => 6,
+                _ => 6
+            };
+
+            return new BaseJob
+            {
+                Id = $"job_{zone.Id}_{type.ToString().ToLowerInvariant()}",
+                Type = type,
+                Priority = priority,
+                ZoneId = zone.Id,
+                DurationHours = duration,
+                RemainingHours = duration,
+                Repeatable = true
+            };
+        }
+    }
+
+    public sealed class BaseJob
+    {
+        public string Id { get; set; } = string.Empty;
+        public BaseJobType Type { get; set; }
+        public BaseJobPriority Priority { get; set; }
+        public string? ZoneId { get; set; }
+        public int DurationHours { get; set; }
+        public int RemainingHours { get; set; }
+        public bool Repeatable { get; set; }
+    }
+
+    public readonly struct BaseJobResult
+    {
+        public BaseJobResult(string id, BaseJobType type, string? zoneId, BaseJobPriority priority, int durationHours)
+        {
+            Id = id ?? throw new ArgumentNullException(nameof(id));
+            Type = type;
+            ZoneId = zoneId;
+            Priority = priority;
+            DurationHours = durationHours;
+        }
+
+        public string Id { get; }
+        public BaseJobType Type { get; }
+        public string? ZoneId { get; }
+        public BaseJobPriority Priority { get; }
+        public int DurationHours { get; }
+    }
+
+    public enum BaseJobType
+    {
+        Maintenance,
+        Production,
+        Research,
+        Patrol
+    }
+
+    public enum BaseJobPriority
+    {
+        Low = 0,
+        Normal = 1,
+        High = 2,
+        Critical = 3
+    }
+
+    public sealed class RaidThreatState
+    {
+        public float ThreatMeter { get; set; } = 0.3f;
+        public bool RaidScheduled { get; set; }
+        public int HoursUntilRaid { get; set; }
+        public string AttackingFactionId { get; set; } = string.Empty;
+    }
+
+    public sealed class MandateTracker
+    {
+        private readonly List<BaseMandate> _mandates = new();
+        private readonly int _hoursPerDay;
+        private int _hourAccumulator;
+
+        public MandateTracker(int hoursPerDay)
+        {
+            if (hoursPerDay <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(hoursPerDay));
+            }
+
+            _hoursPerDay = hoursPerDay;
+        }
+
+        public IReadOnlyList<BaseMandate> Mandates => _mandates;
+
+        public void Initialize(WorldData world, BaseState state)
+        {
+            if (world == null)
+            {
+                throw new ArgumentNullException(nameof(world));
+            }
+
+            if (state == null)
+            {
+                throw new ArgumentNullException(nameof(state));
+            }
+
+            _mandates.Clear();
+
+            var issuer = world.Characters.FirstOrDefault()?.Id ?? string.Empty;
+            var hasWorkshop = state.Zones.Any(z => z.Type == ZoneType.Workshop);
+            var hasResearch = state.Zones.Any(z => z.Type == ZoneType.ResearchLab);
+
+            _mandates.Add(new BaseMandate
+            {
+                Id = "mandate_secure_water",
+                IssuerCharacterId = issuer,
+                Type = MandateType.Infrastructure,
+                Status = MandateStatus.Active,
+                TargetJobType = BaseJobType.Maintenance,
+                RequiredCompletions = 2,
+                DaysRemaining = 4
+            });
+
+            if (hasWorkshop)
+            {
+                _mandates.Add(new BaseMandate
+                {
+                    Id = "mandate_stockpile_supplies",
+                    IssuerCharacterId = issuer,
+                    Type = MandateType.Production,
+                    Status = MandateStatus.Active,
+                    TargetJobType = BaseJobType.Production,
+                    RequiredCompletions = 3,
+                    DaysRemaining = 5
+                });
+            }
+
+            if (hasResearch)
+            {
+                _mandates.Add(new BaseMandate
+                {
+                    Id = "mandate_finish_research",
+                    IssuerCharacterId = issuer,
+                    Type = MandateType.Research,
+                    Status = MandateStatus.Active,
+                    TargetJobType = BaseJobType.Research,
+                    RequiredCompletions = 2,
+                    DaysRemaining = 6
+                });
+            }
+        }
+
+        public IReadOnlyList<BaseMandateResolution> Advance(in BaseModeTickContext context, IReadOnlyList<BaseJobResult> completedJobs)
+        {
+            if (_mandates.Count == 0)
+            {
+                return Array.Empty<BaseMandateResolution>();
+            }
+
+            _hourAccumulator++;
+            if (_hourAccumulator < _hoursPerDay)
+            {
+                return Array.Empty<BaseMandateResolution>();
+            }
+
+            _hourAccumulator = 0;
+            var resolutions = new List<BaseMandateResolution>();
+
+            foreach (var mandate in _mandates)
+            {
+                if (mandate.Status != MandateStatus.Active)
+                {
+                    continue;
+                }
+
+                var progress = completedJobs.Count(job => job.Type == mandate.TargetJobType);
+                if (progress > 0)
+                {
+                    mandate.CompletedCount += progress;
+                    if (mandate.CompletedCount >= mandate.RequiredCompletions)
+                    {
+                        mandate.Status = MandateStatus.Completed;
+                        resolutions.Add(new BaseMandateResolution(mandate, MandateStatus.Completed));
+                        continue;
+                    }
+                }
+
+                mandate.DaysRemaining--;
+                if (mandate.DaysRemaining < 0)
+                {
+                    mandate.Status = MandateStatus.Failed;
+                    resolutions.Add(new BaseMandateResolution(mandate, MandateStatus.Failed));
+                }
+            }
+
+            return resolutions;
+        }
+
+        public void EnqueueFollowUpMandate(BaseMandate source, long tick)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            var followUp = new BaseMandate
+            {
+                Id = $"mandate_followup_{tick:D6}_{source.Type.ToString().ToLowerInvariant()}",
+                IssuerCharacterId = source.IssuerCharacterId,
+                Type = source.Type,
+                Status = MandateStatus.Active,
+                TargetJobType = source.TargetJobType,
+                RequiredCompletions = Math.Max(1, source.RequiredCompletions),
+                DaysRemaining = Math.Max(3, source.DaysRemaining + 3)
+            };
+
+            _mandates.Add(followUp);
+        }
+    }
+
+    public sealed class BaseMandate
+    {
+        public string Id { get; set; } = string.Empty;
+        public string IssuerCharacterId { get; set; } = string.Empty;
+        public MandateType Type { get; set; }
+        public MandateStatus Status { get; set; }
+        public BaseJobType TargetJobType { get; set; }
+        public int RequiredCompletions { get; set; }
+        public int CompletedCount { get; set; }
+        public int DaysRemaining { get; set; }
+    }
+
+    public enum MandateType
+    {
+        Infrastructure,
+        Production,
+        Defense,
+        Research
+    }
+
+    public enum MandateStatus
+    {
+        Active,
+        Completed,
+        Failed
+    }
+
+    public readonly struct BaseMandateResolution
+    {
+        public BaseMandateResolution(BaseMandate mandate, MandateStatus result)
+        {
+            Mandate = mandate ?? throw new ArgumentNullException(nameof(mandate));
+            Result = result;
+        }
+
+        public BaseMandate Mandate { get; }
+        public MandateStatus Result { get; }
+    }
+}

--- a/Assets/_Project/Scripts/BaseMode/BaseSceneBootstrapper.cs
+++ b/Assets/_Project/Scripts/BaseMode/BaseSceneBootstrapper.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Wastelands.Core.Data;
+using Wastelands.Core.Management;
+
+namespace Wastelands.BaseMode
+{
+    /// <summary>
+    /// Composition root for the Base scene. Creates runtime state, registers simulation loop,
+    /// and signals readiness via the deterministic event bus.
+    /// </summary>
+    public sealed class BaseSceneBootstrapper
+    {
+        private readonly WorldData _world;
+        private readonly DeterministicServiceContainer _services;
+        private readonly List<IBaseModeSystem> _systems;
+        private readonly int _hoursPerDay;
+
+        public BaseSceneBootstrapper(WorldData world, DeterministicServiceContainer services, IEnumerable<IBaseModeSystem>? systems = null, int hoursPerDay = 24)
+        {
+            _world = world ?? throw new ArgumentNullException(nameof(world));
+            _services = services ?? throw new ArgumentNullException(nameof(services));
+            if (hoursPerDay <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(hoursPerDay));
+            }
+
+            _hoursPerDay = hoursPerDay;
+            _systems = systems?.ToList() ?? new List<IBaseModeSystem>();
+        }
+
+        public BaseRuntimeState? Runtime { get; private set; }
+        public BaseModeSimulationLoop? SimulationLoop { get; private set; }
+
+        public void Initialize()
+        {
+            WorldDataNormalizer.Normalize(_world);
+            var baseState = _world.BaseState ?? throw new InvalidOperationException("World data is missing BaseState.");
+            baseState.Active = true;
+
+            Runtime = new BaseRuntimeState(_world, baseState, _hoursPerDay);
+            Runtime.SeedInitialJobs();
+            Runtime.SeedInitialMandates(_world);
+
+            if (_systems.Count == 0)
+            {
+                _systems.AddRange(CreateDefaultSystems());
+            }
+
+            SimulationLoop = new BaseModeSimulationLoop(_world, Runtime, _systems, _services.RngService);
+            _services.TickManager.RegisterSystem(SimulationLoop);
+            _services.EventBus.Publish(new BaseSceneBootstrapped(Runtime));
+        }
+
+        private static IEnumerable<IBaseModeSystem> CreateDefaultSystems()
+        {
+            return new IBaseModeSystem[]
+            {
+                new ZoneMaintenanceSystem(),
+                new JobSchedulingSystem(),
+                new RaidThreatSystem(),
+                new MandateResolutionSystem()
+            };
+        }
+    }
+
+    public readonly struct BaseSceneBootstrapped
+    {
+        public BaseSceneBootstrapped(BaseRuntimeState runtime)
+        {
+            Runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        }
+
+        public BaseRuntimeState Runtime { get; }
+    }
+}

--- a/Assets/_Project/Scripts/BaseMode/Systems/BaseModeSystems.cs
+++ b/Assets/_Project/Scripts/BaseMode/Systems/BaseModeSystems.cs
@@ -1,0 +1,460 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Wastelands.Core.Data;
+
+namespace Wastelands.BaseMode
+{
+    internal static class BaseMath
+    {
+        public static float Clamp01(float value)
+        {
+            if (value < 0f)
+            {
+                return 0f;
+            }
+
+            if (value > 1f)
+            {
+                return 1f;
+            }
+
+            return value;
+        }
+
+        public static float Clamp(float value, float min, float max)
+        {
+            if (value < min)
+            {
+                return min;
+            }
+
+            if (value > max)
+            {
+                return max;
+            }
+
+            return value;
+        }
+    }
+
+    public sealed class ZoneMaintenanceSystem : IBaseModeSystem
+    {
+        public string Name => "zones";
+
+        public void Execute(in BaseModeTickContext context)
+        {
+            foreach (var zoneRuntime in context.Runtime.EnumerateZones())
+            {
+                var channel = context.GetChannel($"{Name}.{zoneRuntime.Zone.Id}");
+                var moraleDrift = (float)(channel.NextDouble() * 0.1d - 0.05d);
+                var infrastructureFactor = CalculateInfrastructureFactor(context.BaseState.Infrastructure, zoneRuntime.Zone.Type);
+                zoneRuntime.MoraleModifier = BaseMath.Clamp(zoneRuntime.MoraleModifier + moraleDrift + infrastructureFactor * 0.05f, 0.1f, 1.5f);
+
+                var wearDelta = 0.015f - zoneRuntime.MoraleModifier * 0.01f - infrastructureFactor * 0.01f;
+                zoneRuntime.Wear = BaseMath.Clamp(zoneRuntime.Wear + wearDelta, 0f, 1f);
+
+                var efficiencyDelta = zoneRuntime.MoraleModifier * 0.03f - zoneRuntime.Wear * 0.025f + infrastructureFactor * 0.02f;
+                zoneRuntime.Zone.Efficiency = BaseMath.Clamp(zoneRuntime.Zone.Efficiency + efficiencyDelta, 0.3f, 1.35f);
+
+                if (zoneRuntime.Zone.Type == ZoneType.Watchtower)
+                {
+                    context.Runtime.RaidThreat.ThreatMeter = BaseMath.Clamp01(context.Runtime.RaidThreat.ThreatMeter - zoneRuntime.Zone.Efficiency * 0.01f);
+                }
+            }
+
+            ApplyInfrastructureDecay(context.BaseState);
+        }
+
+        private static float CalculateInfrastructureFactor(IReadOnlyDictionary<string, float> infrastructure, ZoneType zoneType)
+        {
+            if (infrastructure.Count == 0)
+            {
+                return 0f;
+            }
+
+            var baseline = infrastructure.TryGetValue("power", out var power) ? power : 0.5f;
+            var support = infrastructure.TryGetValue("water", out var water) ? water : 0.5f;
+            var morale = infrastructure.TryGetValue("morale", out var moraleValue) ? moraleValue : 0.5f;
+            var defense = infrastructure.TryGetValue("defense", out var defenseValue) ? defenseValue : 0.5f;
+
+            return zoneType switch
+            {
+                ZoneType.Habitat => (baseline + support + morale) / 3f,
+                ZoneType.Workshop => (baseline + morale) / 2f,
+                ZoneType.Farm => (support + morale) / 2f,
+                ZoneType.Watchtower => (baseline + defense) / 2f,
+                ZoneType.ResearchLab => (baseline + morale) / 2f,
+                _ => baseline
+            };
+        }
+
+        private static void ApplyInfrastructureDecay(BaseState state)
+        {
+            var keys = new[] { "power", "water", "morale" };
+            foreach (var key in keys)
+            {
+                if (!state.Infrastructure.TryGetValue(key, out var value))
+                {
+                    state.Infrastructure[key] = 0.5f;
+                    continue;
+                }
+
+                state.Infrastructure[key] = BaseMath.Clamp(value - 0.01f, 0f, 1.5f);
+            }
+
+            if (!state.Infrastructure.ContainsKey("defense"))
+            {
+                state.Infrastructure["defense"] = 0.4f;
+            }
+        }
+    }
+
+    public sealed class JobSchedulingSystem : IBaseModeSystem
+    {
+        public string Name => "jobs";
+
+        public void Execute(in BaseModeTickContext context)
+        {
+            var completed = new List<BaseJobResult>();
+            context.Runtime.JobBoard.Advance(context, completed);
+            context.Runtime.RecordCompletedJobs(completed);
+
+            foreach (var result in completed)
+            {
+                ApplyJobOutcome(result, context);
+                context.EventBus.Publish(new BaseJobCompleted(result, context.Tick));
+            }
+        }
+
+        private static void ApplyJobOutcome(BaseJobResult result, in BaseModeTickContext context)
+        {
+            switch (result.Type)
+            {
+                case BaseJobType.Maintenance:
+                    ApplyMaintenance(result, context);
+                    break;
+                case BaseJobType.Production:
+                    ApplyProduction(result, context);
+                    break;
+                case BaseJobType.Research:
+                    ApplyResearch(result, context);
+                    break;
+                case BaseJobType.Patrol:
+                    ApplyPatrol(result, context);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(result.Type), result.Type, "Unsupported job type.");
+            }
+        }
+
+        private static void ApplyMaintenance(BaseJobResult result, in BaseModeTickContext context)
+        {
+            if (result.ZoneId != null && context.Runtime.TryGetZoneRuntime(result.ZoneId, out var runtime))
+            {
+                runtime.Wear = BaseMath.Clamp(runtime.Wear - 0.2f, 0f, 1f);
+                runtime.Zone.Efficiency = BaseMath.Clamp(runtime.Zone.Efficiency + 0.04f, 0.3f, 1.4f);
+            }
+
+            AdjustInfrastructure(context.BaseState.Infrastructure, "morale", 0.05f);
+        }
+
+        private static void ApplyProduction(BaseJobResult result, in BaseModeTickContext context)
+        {
+            var channel = context.GetChannel($"{nameof(BaseJobType.Production)}.{result.ZoneId ?? "global"}");
+            var yield = 2 + channel.NextInt(0, 3);
+            var itemId = result.ZoneId != null && context.BaseState.Zones.FirstOrDefault(z => z.Id == result.ZoneId)?.Type == ZoneType.Farm
+                ? "supply_food"
+                : "supply_basic";
+
+            var stack = context.BaseState.Inventory.FirstOrDefault(s => string.Equals(s.ItemId, itemId, StringComparison.Ordinal));
+            if (stack == null)
+            {
+                context.BaseState.Inventory.Add(new ItemStack { ItemId = itemId, Quantity = yield });
+            }
+            else
+            {
+                stack.Quantity += yield;
+            }
+
+            AdjustInfrastructure(context.BaseState.Infrastructure, "power", 0.02f);
+        }
+
+        private static void ApplyResearch(BaseJobResult result, in BaseModeTickContext context)
+        {
+            if (string.IsNullOrEmpty(context.BaseState.Research.ActiveProjectId))
+            {
+                context.BaseState.Research.ActiveProgress = 0f;
+                return;
+            }
+
+            var channel = context.GetChannel("research.progress");
+            var delta = 0.1f + (float)channel.NextDouble() * 0.05f;
+            context.BaseState.Research.ActiveProgress = BaseMath.Clamp01(context.BaseState.Research.ActiveProgress + delta);
+
+            if (context.BaseState.Research.ActiveProgress >= 0.999f)
+            {
+                context.BaseState.Research.CompletedProjects.Add(context.BaseState.Research.ActiveProjectId);
+                context.BaseState.Research.ActiveProjectId = string.Empty;
+                context.BaseState.Research.ActiveProgress = 0f;
+            }
+        }
+
+        private static void ApplyPatrol(BaseJobResult result, in BaseModeTickContext context)
+        {
+            context.Runtime.RaidThreat.ThreatMeter = BaseMath.Clamp01(context.Runtime.RaidThreat.ThreatMeter - 0.12f);
+            AdjustInfrastructure(context.BaseState.Infrastructure, "defense", 0.05f);
+        }
+
+        private static void AdjustInfrastructure(IDictionary<string, float> infrastructure, string key, float delta)
+        {
+            if (!infrastructure.TryGetValue(key, out var value))
+            {
+                value = 0.5f;
+            }
+
+            infrastructure[key] = BaseMath.Clamp(value + delta, 0f, 1.5f);
+        }
+    }
+
+    public sealed class RaidThreatSystem : IBaseModeSystem
+    {
+        public string Name => "raids";
+
+        public void Execute(in BaseModeTickContext context)
+        {
+            var raidState = context.Runtime.RaidThreat;
+            var channel = context.GetChannel("raids.threat");
+            var tensionModifier = (context.World.OracleState.TensionScore - 0.5f) * 0.08f;
+            var infrastructureModifier = context.BaseState.Infrastructure.TryGetValue("defense", out var defense) ? (0.6f - defense) * 0.05f : 0.02f;
+            var delta = (float)(channel.NextDouble() * 0.06d - 0.02d) + tensionModifier + infrastructureModifier;
+
+            delta -= context.Runtime.RecentlyCompletedJobs.Count(job => job.Type == BaseJobType.Patrol) * 0.04f;
+
+            raidState.ThreatMeter = BaseMath.Clamp01(raidState.ThreatMeter + delta);
+
+            if (raidState.RaidScheduled)
+            {
+                raidState.HoursUntilRaid--;
+                if (raidState.HoursUntilRaid <= 0)
+                {
+                    ResolveRaid(context);
+                }
+
+                return;
+            }
+
+            if (raidState.ThreatMeter > 0.85f)
+            {
+                raidState.RaidScheduled = true;
+                raidState.HoursUntilRaid = Math.Max(4, context.HoursPerDay / 3);
+                raidState.AttackingFactionId = context.World.Factions.FirstOrDefault()?.Id ?? string.Empty;
+                context.BaseState.AlertLevel = AlertLevel.Elevated;
+                context.EventBus.Publish(new BaseRaidScheduled(raidState.AttackingFactionId, raidState.HoursUntilRaid));
+            }
+            else if (context.BaseState.AlertLevel != AlertLevel.Calm && raidState.ThreatMeter < 0.25f)
+            {
+                context.BaseState.AlertLevel = AlertLevel.Calm;
+            }
+        }
+
+        private static void ResolveRaid(in BaseModeTickContext context)
+        {
+            var raidState = context.Runtime.RaidThreat;
+            raidState.RaidScheduled = false;
+            raidState.ThreatMeter = 0.35f;
+            context.BaseState.AlertLevel = AlertLevel.Critical;
+
+            var eventId = $"base_raid_{context.Tick:D6}";
+            context.World.Events.Add(new EventRecord
+            {
+                Id = eventId,
+                Timestamp = context.Tick,
+                EventType = EventType.Raid,
+                Actors = new List<string>(),
+                LocationId = context.BaseState.SiteTileId,
+                Details = new Dictionary<string, string>
+                {
+                    { "attacker", raidState.AttackingFactionId },
+                    { "alertLevel", context.BaseState.AlertLevel.ToString() },
+                    { "threat", raidState.ThreatMeter.ToString("0.00", CultureInfo.InvariantCulture) }
+                }
+            });
+
+            AdjustDefenseAfterRaid(context.BaseState.Infrastructure);
+            context.EventBus.Publish(new BaseRaidResolved(eventId, raidState.AttackingFactionId));
+        }
+
+        private static void AdjustDefenseAfterRaid(IDictionary<string, float> infrastructure)
+        {
+            if (!infrastructure.TryGetValue("defense", out var defense))
+            {
+                defense = 0.4f;
+            }
+
+            infrastructure["defense"] = BaseMath.Clamp(defense - 0.1f, 0f, 1.2f);
+        }
+    }
+
+    public sealed class MandateResolutionSystem : IBaseModeSystem
+    {
+        public string Name => "mandates";
+
+        public void Execute(in BaseModeTickContext context)
+        {
+            var resolutions = context.Runtime.MandateTracker.Advance(context, context.Runtime.RecentlyCompletedJobs);
+            if (resolutions.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var resolution in resolutions)
+            {
+                ApplyResolutionEffects(resolution, context);
+                LogResolutionEvent(resolution, context);
+                context.EventBus.Publish(new BaseMandateResolved(resolution.Mandate, resolution.Result, context.Tick));
+
+                if (resolution.Result == MandateStatus.Completed)
+                {
+                    context.Runtime.MandateTracker.EnqueueFollowUpMandate(resolution.Mandate, context.Tick);
+                }
+            }
+        }
+
+        private static void ApplyResolutionEffects(BaseMandateResolution resolution, in BaseModeTickContext context)
+        {
+            switch (resolution.Result)
+            {
+                case MandateStatus.Completed:
+                    ApplyCompletion(resolution.Mandate, context);
+                    break;
+                case MandateStatus.Failed:
+                    ApplyFailure(context.BaseState.Infrastructure);
+                    break;
+            }
+        }
+
+        private static void ApplyCompletion(BaseMandate mandate, in BaseModeTickContext context)
+        {
+            switch (mandate.Type)
+            {
+                case MandateType.Infrastructure:
+                    AdjustInfrastructure(context.BaseState.Infrastructure, "water", 0.08f);
+                    AdjustInfrastructure(context.BaseState.Infrastructure, "morale", 0.05f);
+                    break;
+                case MandateType.Production:
+                    var stack = context.BaseState.Inventory.FirstOrDefault(item => item.ItemId == "supply_refined");
+                    if (stack == null)
+                    {
+                        context.BaseState.Inventory.Add(new ItemStack { ItemId = "supply_refined", Quantity = 4 });
+                    }
+                    else
+                    {
+                        stack.Quantity += 4;
+                    }
+
+                    AdjustInfrastructure(context.BaseState.Infrastructure, "power", 0.05f);
+                    break;
+                case MandateType.Defense:
+                    AdjustInfrastructure(context.BaseState.Infrastructure, "defense", 0.1f);
+                    context.BaseState.AlertLevel = AlertLevel.Elevated;
+                    break;
+                case MandateType.Research:
+                    if (!string.IsNullOrEmpty(context.BaseState.Research.ActiveProjectId))
+                    {
+                        context.BaseState.Research.CompletedProjects.Add(context.BaseState.Research.ActiveProjectId);
+                        context.BaseState.Research.ActiveProjectId = string.Empty;
+                        context.BaseState.Research.ActiveProgress = 0f;
+                    }
+                    break;
+            }
+        }
+
+        private static void ApplyFailure(IDictionary<string, float> infrastructure)
+        {
+            AdjustInfrastructure(infrastructure, "morale", -0.08f);
+            AdjustInfrastructure(infrastructure, "defense", -0.05f);
+        }
+
+        private static void AdjustInfrastructure(IDictionary<string, float> infrastructure, string key, float delta)
+        {
+            if (!infrastructure.TryGetValue(key, out var value))
+            {
+                value = 0.4f;
+            }
+
+            infrastructure[key] = BaseMath.Clamp(value + delta, 0f, 1.5f);
+        }
+
+        private static void LogResolutionEvent(BaseMandateResolution resolution, in BaseModeTickContext context)
+        {
+            var eventId = $"mandate_{resolution.Mandate.Id}_{context.Tick:D6}";
+            context.World.Events.Add(new EventRecord
+            {
+                Id = eventId,
+                Timestamp = context.Tick,
+                EventType = EventType.Mandate,
+                Actors = string.IsNullOrEmpty(resolution.Mandate.IssuerCharacterId)
+                    ? new List<string>()
+                    : new List<string> { resolution.Mandate.IssuerCharacterId },
+                LocationId = context.BaseState.SiteTileId,
+                Details = new Dictionary<string, string>
+                {
+                    { "result", resolution.Result.ToString() },
+                    { "type", resolution.Mandate.Type.ToString() }
+                }
+            });
+        }
+    }
+
+    public readonly struct BaseJobCompleted
+    {
+        public BaseJobCompleted(BaseJobResult job, long tick)
+        {
+            Job = job;
+            Tick = tick;
+        }
+
+        public BaseJobResult Job { get; }
+        public long Tick { get; }
+    }
+
+    public readonly struct BaseRaidScheduled
+    {
+        public BaseRaidScheduled(string attackerFactionId, int hoursUntilRaid)
+        {
+            AttackerFactionId = attackerFactionId;
+            HoursUntilRaid = hoursUntilRaid;
+        }
+
+        public string AttackerFactionId { get; }
+        public int HoursUntilRaid { get; }
+    }
+
+    public readonly struct BaseRaidResolved
+    {
+        public BaseRaidResolved(string eventId, string attackerFactionId)
+        {
+            EventId = eventId ?? throw new ArgumentNullException(nameof(eventId));
+            AttackerFactionId = attackerFactionId;
+        }
+
+        public string EventId { get; }
+        public string AttackerFactionId { get; }
+    }
+
+    public readonly struct BaseMandateResolved
+    {
+        public BaseMandateResolved(BaseMandate mandate, MandateStatus resolutionResult, long tick)
+        {
+            Mandate = mandate ?? throw new ArgumentNullException(nameof(mandate));
+            ResolutionResult = resolutionResult;
+            Tick = tick;
+        }
+
+        public BaseMandate Mandate { get; }
+        public MandateStatus ResolutionResult { get; }
+        public long Tick { get; }
+    }
+}

--- a/Assets/_Project/Scripts/Persistence/BaseStateDiff.cs
+++ b/Assets/_Project/Scripts/Persistence/BaseStateDiff.cs
@@ -1,0 +1,337 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Wastelands.Core.Data;
+
+namespace Wastelands.Persistence
+{
+    /// <summary>
+    /// Represents a minimal patch describing changes applied to a <see cref="BaseState"/>.
+    /// </summary>
+    public sealed class BaseStateDiff
+    {
+        public bool? Active { get; set; }
+        public string? SiteTileId { get; set; }
+        public AlertLevel? AlertLevel { get; set; }
+        public List<BaseZone> UpsertedZones { get; set; } = new();
+        public List<string> RemovedZoneIds { get; set; } = new();
+        public List<string> AddedPopulation { get; set; } = new();
+        public List<string> RemovedPopulation { get; set; } = new();
+        public Dictionary<string, float> UpsertedInfrastructure { get; set; } = new();
+        public List<string> RemovedInfrastructureKeys { get; set; } = new();
+        public List<ItemStack> UpsertedInventory { get; set; } = new();
+        public List<string> RemovedInventoryItemIds { get; set; } = new();
+        public ResearchState? Research { get; set; }
+    }
+
+    public interface IBaseStateDiffCalculator
+    {
+        BaseStateDiff Compute(BaseState previous, BaseState next);
+        void Apply(BaseState target, BaseStateDiff diff);
+    }
+
+    /// <summary>
+    /// Computes and applies diffs between <see cref="BaseState"/> snapshots for incremental persistence.
+    /// </summary>
+    public sealed class BaseStateDiffCalculator : IBaseStateDiffCalculator
+    {
+        public BaseStateDiff Compute(BaseState previous, BaseState next)
+        {
+            if (previous == null)
+            {
+                throw new ArgumentNullException(nameof(previous));
+            }
+
+            if (next == null)
+            {
+                throw new ArgumentNullException(nameof(next));
+            }
+
+            var diff = new BaseStateDiff();
+
+            if (previous.Active != next.Active)
+            {
+                diff.Active = next.Active;
+            }
+
+            if (!string.Equals(previous.SiteTileId, next.SiteTileId, StringComparison.Ordinal))
+            {
+                diff.SiteTileId = next.SiteTileId;
+            }
+
+            if (previous.AlertLevel != next.AlertLevel)
+            {
+                diff.AlertLevel = next.AlertLevel;
+            }
+
+            PopulateZoneDiff(previous, next, diff);
+            PopulatePopulationDiff(previous, next, diff);
+            PopulateInfrastructureDiff(previous, next, diff);
+            PopulateInventoryDiff(previous, next, diff);
+
+            if (ResearchChanged(previous.Research, next.Research))
+            {
+                diff.Research = CloneResearch(next.Research);
+            }
+
+            return diff;
+        }
+
+        public void Apply(BaseState target, BaseStateDiff diff)
+        {
+            if (target == null)
+            {
+                throw new ArgumentNullException(nameof(target));
+            }
+
+            if (diff == null)
+            {
+                throw new ArgumentNullException(nameof(diff));
+            }
+
+            if (diff.Active.HasValue)
+            {
+                target.Active = diff.Active.Value;
+            }
+
+            if (diff.SiteTileId != null)
+            {
+                target.SiteTileId = diff.SiteTileId;
+            }
+
+            if (diff.AlertLevel.HasValue)
+            {
+                target.AlertLevel = diff.AlertLevel.Value;
+            }
+
+            ApplyZoneDiff(target, diff);
+            ApplyPopulationDiff(target, diff);
+            ApplyInfrastructureDiff(target, diff);
+            ApplyInventoryDiff(target, diff);
+
+            if (diff.Research != null)
+            {
+                target.Research = CloneResearch(diff.Research);
+            }
+        }
+
+        private static void PopulateZoneDiff(BaseState previous, BaseState next, BaseStateDiff diff)
+        {
+            var previousLookup = previous.Zones.ToDictionary(z => z.Id, StringComparer.Ordinal);
+            var nextLookup = next.Zones.ToDictionary(z => z.Id, StringComparer.Ordinal);
+
+            foreach (var pair in nextLookup)
+            {
+                if (!previousLookup.TryGetValue(pair.Key, out var prior) || !ZonesEqual(prior, pair.Value))
+                {
+                    diff.UpsertedZones.Add(CloneZone(pair.Value));
+                }
+            }
+
+            foreach (var pair in previousLookup)
+            {
+                if (!nextLookup.ContainsKey(pair.Key))
+                {
+                    diff.RemovedZoneIds.Add(pair.Key);
+                }
+            }
+        }
+
+        private static void PopulatePopulationDiff(BaseState previous, BaseState next, BaseStateDiff diff)
+        {
+            var previousSet = new HashSet<string>(previous.Population, StringComparer.Ordinal);
+            var nextSet = new HashSet<string>(next.Population, StringComparer.Ordinal);
+
+            diff.AddedPopulation.AddRange(nextSet.Except(previousSet));
+            diff.RemovedPopulation.AddRange(previousSet.Except(nextSet));
+        }
+
+        private static void PopulateInfrastructureDiff(BaseState previous, BaseState next, BaseStateDiff diff)
+        {
+            foreach (var pair in next.Infrastructure)
+            {
+                if (!previous.Infrastructure.TryGetValue(pair.Key, out var priorValue) || !FloatEquals(priorValue, pair.Value))
+                {
+                    diff.UpsertedInfrastructure[pair.Key] = pair.Value;
+                }
+            }
+
+            foreach (var key in previous.Infrastructure.Keys)
+            {
+                if (!next.Infrastructure.ContainsKey(key))
+                {
+                    diff.RemovedInfrastructureKeys.Add(key);
+                }
+            }
+        }
+
+        private static void PopulateInventoryDiff(BaseState previous, BaseState next, BaseStateDiff diff)
+        {
+            var previousLookup = previous.Inventory.ToDictionary(item => item.ItemId, StringComparer.Ordinal);
+            var nextLookup = next.Inventory.ToDictionary(item => item.ItemId, StringComparer.Ordinal);
+
+            foreach (var pair in nextLookup)
+            {
+                if (!previousLookup.TryGetValue(pair.Key, out var prior) || prior.Quantity != pair.Value.Quantity)
+                {
+                    diff.UpsertedInventory.Add(new ItemStack { ItemId = pair.Key, Quantity = pair.Value.Quantity });
+                }
+            }
+
+            foreach (var pair in previousLookup)
+            {
+                if (!nextLookup.ContainsKey(pair.Key))
+                {
+                    diff.RemovedInventoryItemIds.Add(pair.Key);
+                }
+            }
+        }
+
+        private static void ApplyZoneDiff(BaseState target, BaseStateDiff diff)
+        {
+            foreach (var zone in diff.UpsertedZones)
+            {
+                var existing = target.Zones.FirstOrDefault(z => string.Equals(z.Id, zone.Id, StringComparison.Ordinal));
+                if (existing == null)
+                {
+                    target.Zones.Add(CloneZone(zone));
+                    continue;
+                }
+
+                existing.Name = zone.Name;
+                existing.Type = zone.Type;
+                existing.Efficiency = zone.Efficiency;
+            }
+
+            if (diff.RemovedZoneIds.Count == 0)
+            {
+                return;
+            }
+
+            target.Zones = target.Zones
+                .Where(z => !diff.RemovedZoneIds.Contains(z.Id, StringComparer.Ordinal))
+                .ToList();
+        }
+
+        private static void ApplyPopulationDiff(BaseState target, BaseStateDiff diff)
+        {
+            if (diff.AddedPopulation.Count > 0)
+            {
+                foreach (var member in diff.AddedPopulation)
+                {
+                    if (!target.Population.Contains(member, StringComparer.Ordinal))
+                    {
+                        target.Population.Add(member);
+                    }
+                }
+            }
+
+            if (diff.RemovedPopulation.Count > 0)
+            {
+                target.Population = target.Population
+                    .Where(member => !diff.RemovedPopulation.Contains(member, StringComparer.Ordinal))
+                    .ToList();
+            }
+        }
+
+        private static void ApplyInfrastructureDiff(BaseState target, BaseStateDiff diff)
+        {
+            foreach (var pair in diff.UpsertedInfrastructure)
+            {
+                target.Infrastructure[pair.Key] = pair.Value;
+            }
+
+            foreach (var key in diff.RemovedInfrastructureKeys)
+            {
+                target.Infrastructure.Remove(key);
+            }
+        }
+
+        private static void ApplyInventoryDiff(BaseState target, BaseStateDiff diff)
+        {
+            foreach (var stack in diff.UpsertedInventory)
+            {
+                var existing = target.Inventory.FirstOrDefault(item => string.Equals(item.ItemId, stack.ItemId, StringComparison.Ordinal));
+                if (existing == null)
+                {
+                    target.Inventory.Add(new ItemStack { ItemId = stack.ItemId, Quantity = stack.Quantity });
+                }
+                else
+                {
+                    existing.Quantity = stack.Quantity;
+                }
+            }
+
+            if (diff.RemovedInventoryItemIds.Count == 0)
+            {
+                return;
+            }
+
+            target.Inventory = target.Inventory
+                .Where(item => !diff.RemovedInventoryItemIds.Contains(item.ItemId, StringComparer.Ordinal))
+                .ToList();
+        }
+
+        private static bool ZonesEqual(BaseZone left, BaseZone right)
+        {
+            return string.Equals(left.Id, right.Id, StringComparison.Ordinal)
+                   && string.Equals(left.Name, right.Name, StringComparison.Ordinal)
+                   && left.Type == right.Type
+                   && FloatEquals(left.Efficiency, right.Efficiency);
+        }
+
+        private static bool ResearchChanged(ResearchState previous, ResearchState next)
+        {
+            if (!string.Equals(previous.ActiveProjectId, next.ActiveProjectId, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            if (!FloatEquals(previous.ActiveProgress, next.ActiveProgress))
+            {
+                return true;
+            }
+
+            if (previous.CompletedProjects.Count != next.CompletedProjects.Count)
+            {
+                return true;
+            }
+
+            for (var i = 0; i < previous.CompletedProjects.Count; i++)
+            {
+                if (!string.Equals(previous.CompletedProjects[i], next.CompletedProjects[i], StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static BaseZone CloneZone(BaseZone zone)
+        {
+            return new BaseZone
+            {
+                Id = zone.Id,
+                Name = zone.Name,
+                Type = zone.Type,
+                Efficiency = zone.Efficiency
+            };
+        }
+
+        private static ResearchState CloneResearch(ResearchState research)
+        {
+            return new ResearchState
+            {
+                CompletedProjects = research.CompletedProjects.Select(id => id).ToList(),
+                ActiveProjectId = research.ActiveProjectId,
+                ActiveProgress = research.ActiveProgress
+            };
+        }
+
+        private static bool FloatEquals(float a, float b)
+        {
+            return Math.Abs(a - b) < 0.0001f;
+        }
+    }
+}

--- a/Tests/EditMode/BaseModeSimulationLoopTests.cs
+++ b/Tests/EditMode/BaseModeSimulationLoopTests.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Wastelands.BaseMode;
+using Wastelands.Core.Data;
+using Wastelands.Core.Management;
+using Wastelands.Core.Services;
+using Wastelands.Persistence;
+
+namespace Wastelands.Tests.EditMode
+{
+    public class BaseModeSimulationLoopTests
+    {
+        [Test]
+        public void Bootstrapper_InitializesRuntimeAndRegistersLoop()
+        {
+            var world = SampleWorldBuilder.CreateValidWorld();
+            var services = CreateServices();
+            var bootstrapper = new BaseSceneBootstrapper(world, services);
+
+            BaseRuntimeState? runtimeFromEvent = null;
+            services.EventBus.Subscribe<BaseSceneBootstrapped>(evt => runtimeFromEvent = evt.Runtime);
+
+            bootstrapper.Initialize();
+
+            Assert.IsNotNull(bootstrapper.Runtime);
+            Assert.IsNotNull(bootstrapper.SimulationLoop);
+            Assert.IsNotNull(runtimeFromEvent);
+            Assert.IsTrue(world.BaseState.Active);
+            Assert.That(bootstrapper.Runtime!.JobBoard.Jobs, Is.Not.Empty);
+            Assert.That(bootstrapper.Runtime.MandateTracker.Mandates, Is.Not.Empty);
+
+            Assert.DoesNotThrow(() => services.TickManager.Advance(1));
+        }
+
+        [Test]
+        public void SimulationLoop_ProducesDeterministicResults()
+        {
+            var worldA = SampleWorldBuilder.CreateValidWorld();
+            var worldB = SampleWorldBuilder.CreateValidWorld();
+
+            var resultA = RunSimulation(worldA, ticks: 72);
+            var resultB = RunSimulation(worldB, ticks: 72);
+
+            Assert.That(resultA.JobCompletions, Is.Not.Empty);
+            Assert.That(resultA.MandateResolutions, Is.Not.Empty);
+            Assert.AreEqual(resultA.JobCompletions, resultB.JobCompletions);
+            Assert.AreEqual(resultA.MandateResolutions, resultB.MandateResolutions);
+
+            var serializer = new WorldDataSerializer();
+            Assert.AreEqual(serializer.Serialize(worldA), serializer.Serialize(worldB));
+        }
+
+        private static SimulationResult RunSimulation(WorldData world, int ticks)
+        {
+            var services = CreateServices();
+            var bootstrapper = new BaseSceneBootstrapper(world, services);
+
+            var jobCompletions = new List<string>();
+            var mandateResolutions = new List<string>();
+            var raidEvents = new List<string>();
+
+            services.EventBus.Subscribe<BaseJobCompleted>(evt => jobCompletions.Add(evt.Job.Id));
+            services.EventBus.Subscribe<BaseMandateResolved>(evt => mandateResolutions.Add($"{evt.ResolutionResult}:{evt.Mandate.Id}:{evt.Tick}"));
+            services.EventBus.Subscribe<BaseRaidResolved>(evt => raidEvents.Add(evt.EventId));
+
+            bootstrapper.Initialize();
+            services.TickManager.Advance(ticks);
+
+            return new SimulationResult(jobCompletions, mandateResolutions, raidEvents);
+        }
+
+        private static DeterministicServiceContainer CreateServices()
+        {
+            var timeProvider = new ManualTimeProvider(ticksPerYear: 1, ticksPerDay: 24);
+            var rng = new DeterministicRngService(1337);
+            var eventBus = new EventBus();
+            var tickManager = new TickManager(timeProvider, rng, eventBus);
+            return new DeterministicServiceContainer(timeProvider, rng, eventBus, tickManager);
+        }
+
+        private readonly struct SimulationResult
+        {
+            public SimulationResult(List<string> jobCompletions, List<string> mandateResolutions, List<string> raidEvents)
+            {
+                JobCompletions = jobCompletions;
+                MandateResolutions = mandateResolutions;
+                RaidEvents = raidEvents;
+            }
+
+            public List<string> JobCompletions { get; }
+            public List<string> MandateResolutions { get; }
+            public List<string> RaidEvents { get; }
+        }
+    }
+}

--- a/Tests/EditMode/BaseStateDiffTests.cs
+++ b/Tests/EditMode/BaseStateDiffTests.cs
@@ -1,0 +1,161 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Wastelands.Core.Data;
+using Wastelands.Persistence;
+
+namespace Wastelands.Tests.EditMode
+{
+    public class BaseStateDiffTests
+    {
+        [Test]
+        public void Compute_NoChangesProducesEmptyDiff()
+        {
+            var world = SampleWorldBuilder.CreateValidWorld();
+            var calculator = new BaseStateDiffCalculator();
+            var previous = Clone(world.BaseState);
+            var next = Clone(world.BaseState);
+
+            var diff = calculator.Compute(previous, next);
+
+            Assert.IsNull(diff.Active);
+            Assert.IsNull(diff.SiteTileId);
+            Assert.IsNull(diff.AlertLevel);
+            Assert.IsEmpty(diff.UpsertedZones);
+            Assert.IsEmpty(diff.RemovedZoneIds);
+            Assert.IsEmpty(diff.AddedPopulation);
+            Assert.IsEmpty(diff.RemovedPopulation);
+            Assert.IsEmpty(diff.UpsertedInfrastructure);
+            Assert.IsEmpty(diff.RemovedInfrastructureKeys);
+            Assert.IsEmpty(diff.UpsertedInventory);
+            Assert.IsEmpty(diff.RemovedInventoryItemIds);
+            Assert.IsNull(diff.Research);
+        }
+
+        [Test]
+        public void ComputeAndApplyDiff_RoundTripsChanges()
+        {
+            var world = SampleWorldBuilder.CreateValidWorld();
+            var calculator = new BaseStateDiffCalculator();
+            var previous = Clone(world.BaseState);
+            var next = Clone(world.BaseState);
+
+            next.Active = !previous.Active;
+            next.SiteTileId = "tile_custom";
+            next.AlertLevel = AlertLevel.Elevated;
+
+            next.Zones[0].Efficiency = BaseClamp(next.Zones[0].Efficiency + 0.1f);
+            next.Zones.Add(new BaseZone
+            {
+                Id = "zone_new",
+                Name = "New Zone",
+                Type = ZoneType.Workshop,
+                Efficiency = 0.95f
+            });
+
+            next.Population.Add("char_new");
+            if (next.Population.Count > 0)
+            {
+                next.Population.RemoveAt(0);
+            }
+
+            next.Infrastructure["power"] = 1.2f;
+            next.Infrastructure["morale"] = 0.9f;
+            next.Infrastructure.Remove("water");
+            next.Infrastructure["defense"] = 0.6f;
+
+            if (next.Inventory.Count > 0)
+            {
+                next.Inventory[0].Quantity += 7;
+            }
+
+            next.Inventory.Add(new ItemStack { ItemId = "supply_new", Quantity = 5 });
+
+            next.Research.ActiveProjectId = "tech_new";
+            next.Research.ActiveProgress = 0.6f;
+            next.Research.CompletedProjects.Add("tech_old");
+
+            var diff = calculator.Compute(previous, next);
+            var target = Clone(previous);
+            calculator.Apply(target, diff);
+
+            AssertBaseStateEqual(next, target);
+        }
+
+        private static BaseState Clone(BaseState source)
+        {
+            return new BaseState
+            {
+                Active = source.Active,
+                SiteTileId = source.SiteTileId,
+                Zones = source.Zones.Select(zone => new BaseZone
+                {
+                    Id = zone.Id,
+                    Name = zone.Name,
+                    Type = zone.Type,
+                    Efficiency = zone.Efficiency
+                }).ToList(),
+                Population = new List<string>(source.Population),
+                Infrastructure = source.Infrastructure.ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal),
+                AlertLevel = source.AlertLevel,
+                Inventory = source.Inventory.Select(item => new ItemStack { ItemId = item.ItemId, Quantity = item.Quantity }).ToList(),
+                Research = new ResearchState
+                {
+                    ActiveProjectId = source.Research.ActiveProjectId,
+                    ActiveProgress = source.Research.ActiveProgress,
+                    CompletedProjects = new List<string>(source.Research.CompletedProjects)
+                }
+            };
+        }
+
+        private static void AssertBaseStateEqual(BaseState expected, BaseState actual)
+        {
+            Assert.AreEqual(expected.Active, actual.Active);
+            Assert.AreEqual(expected.SiteTileId, actual.SiteTileId);
+            Assert.AreEqual(expected.AlertLevel, actual.AlertLevel);
+
+            CollectionAssert.AreEquivalent(expected.Zones.Select(z => z.Id), actual.Zones.Select(z => z.Id));
+            foreach (var zone in expected.Zones)
+            {
+                var match = actual.Zones.Single(z => z.Id == zone.Id);
+                Assert.AreEqual(zone.Name, match.Name);
+                Assert.AreEqual(zone.Type, match.Type);
+                Assert.That(match.Efficiency, Is.EqualTo(zone.Efficiency).Within(0.0001f));
+            }
+
+            CollectionAssert.AreEquivalent(expected.Population, actual.Population);
+
+            CollectionAssert.AreEquivalent(expected.Infrastructure.Keys, actual.Infrastructure.Keys);
+            foreach (var pair in expected.Infrastructure)
+            {
+                Assert.That(actual.Infrastructure[pair.Key], Is.EqualTo(pair.Value).Within(0.0001f));
+            }
+
+            CollectionAssert.AreEquivalent(expected.Inventory.Select(item => item.ItemId), actual.Inventory.Select(item => item.ItemId));
+            foreach (var item in expected.Inventory)
+            {
+                var match = actual.Inventory.Single(i => i.ItemId == item.ItemId);
+                Assert.AreEqual(item.Quantity, match.Quantity);
+            }
+
+            Assert.AreEqual(expected.Research.ActiveProjectId, actual.Research.ActiveProjectId);
+            Assert.That(actual.Research.ActiveProgress, Is.EqualTo(expected.Research.ActiveProgress).Within(0.0001f));
+            CollectionAssert.AreEqual(expected.Research.CompletedProjects, actual.Research.CompletedProjects);
+        }
+
+        private static float BaseClamp(float value)
+        {
+            if (value < 0f)
+            {
+                return 0f;
+            }
+
+            if (value > 1.5f)
+            {
+                return 1.5f;
+            }
+
+            return value;
+        }
+    }
+}

--- a/Tests/EditMode/Wastelands.Tests.EditMode.asmdef
+++ b/Tests/EditMode/Wastelands.Tests.EditMode.asmdef
@@ -3,6 +3,7 @@
   "references": [
     "Wastelands.Core",
     "Wastelands.Persistence",
+    "Wastelands.BaseMode",
     "Wastelands.Generation",
     "Wastelands.Simulation",
     "Wastelands.UI",


### PR DESCRIPTION
## Summary
- add a scene bootstrapper and runtime scaffolding for deterministic base mode ticks
- implement base mode systems (zones, jobs, raids, mandates) with event logging and tick integration
- introduce base state diff calculator and edit mode coverage for base mode bootstrap and persistence round-trips

## Testing
- not run (Unity project / edit mode tests require Unity Test Runner)


------
https://chatgpt.com/codex/tasks/task_e_68dd01ee9c4c8329813a81f6c8495200