### PR TITLE
Integrate base scene bootstrapper with debug HUD and indirect command flow

### DIFF
--- a/Assets/_Project/Scripts/BaseMode/BaseIndirectCommandDispatcher.cs
+++ b/Assets/_Project/Scripts/BaseMode/BaseIndirectCommandDispatcher.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Wastelands.Core.Services;
+
+namespace Wastelands.BaseMode
+{
+    public interface IBaseIndirectCommandDispatcher
+    {
+        IReadOnlyList<BaseIndirectCommand> RecentCommands { get; }
+        void Issue(BaseIndirectCommand command);
+    }
+
+    public sealed class BaseIndirectCommandDispatcher : IBaseIndirectCommandDispatcher
+    {
+        private readonly IEventBus _eventBus;
+        private readonly List<BaseIndirectCommand> _recentCommands = new();
+        private readonly int _historyLimit;
+
+        public BaseIndirectCommandDispatcher(IEventBus eventBus, int historyLimit = 32)
+        {
+            _eventBus = eventBus ?? throw new ArgumentNullException(nameof(eventBus));
+
+            if (historyLimit <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(historyLimit));
+            }
+
+            _historyLimit = historyLimit;
+            RecentCommands = new ReadOnlyCollection<BaseIndirectCommand>(_recentCommands);
+        }
+
+        public IReadOnlyList<BaseIndirectCommand> RecentCommands { get; }
+
+        public void Issue(BaseIndirectCommand command)
+        {
+            if (string.IsNullOrWhiteSpace(command.CommandType))
+            {
+                throw new ArgumentException("CommandType must be provided.", nameof(command));
+            }
+
+            _recentCommands.Add(command);
+            if (_recentCommands.Count > _historyLimit)
+            {
+                _recentCommands.RemoveAt(0);
+            }
+
+            _eventBus.Publish(new BaseIndirectCommandQueued(command));
+        }
+    }
+
+    public readonly struct BaseIndirectCommand
+    {
+        public BaseIndirectCommand(string commandType, string? targetId = null, IReadOnlyDictionary<string, string>? payload = null)
+        {
+            if (string.IsNullOrWhiteSpace(commandType))
+            {
+                throw new ArgumentException("Command type must be supplied.", nameof(commandType));
+            }
+
+            CommandType = commandType;
+            TargetId = targetId;
+            Payload = payload != null
+                ? new ReadOnlyDictionary<string, string>(payload.ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal))
+                : EmptyPayload;
+        }
+
+        public string CommandType { get; }
+        public string? TargetId { get; }
+        public IReadOnlyDictionary<string, string> Payload { get; }
+
+        private static IReadOnlyDictionary<string, string> EmptyPayload { get; } = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>());
+    }
+
+    public readonly struct BaseIndirectCommandQueued
+    {
+        public BaseIndirectCommandQueued(BaseIndirectCommand command)
+        {
+            Command = command;
+        }
+
+        public BaseIndirectCommand Command { get; }
+    }
+
+    public readonly struct BaseIndirectCommandDispatcherReady
+    {
+        public BaseIndirectCommandDispatcherReady(IBaseIndirectCommandDispatcher dispatcher)
+        {
+            Dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        }
+
+        public IBaseIndirectCommandDispatcher Dispatcher { get; }
+    }
+}

--- a/Assets/_Project/Scripts/BaseMode/BaseRuntimeState.cs
+++ b/Assets/_Project/Scripts/BaseMode/BaseRuntimeState.cs
@@ -39,6 +39,7 @@ namespace Wastelands.BaseMode
         public List<BaseJobResult> RecentlyCompletedJobs => _recentlyCompletedJobs;
 
         public IReadOnlyDictionary<string, BaseZoneRuntime> Zones => _zonesById;
+        public IBaseIndirectCommandDispatcher? CommandDispatcher { get; private set; }
 
         public IEnumerable<BaseZoneRuntime> EnumerateZones() => _zonesById.Values;
 
@@ -55,6 +56,11 @@ namespace Wastelands.BaseMode
         public void SeedInitialMandates(WorldData world)
         {
             MandateTracker.Initialize(world, BaseState);
+        }
+
+        public void BindCommandDispatcher(IBaseIndirectCommandDispatcher dispatcher)
+        {
+            CommandDispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
         }
 
         public void RecordCompletedJobs(IEnumerable<BaseJobResult> jobs)

--- a/Assets/_Project/Scripts/BaseMode/Unity/BaseSceneDebugHud.cs
+++ b/Assets/_Project/Scripts/BaseMode/Unity/BaseSceneDebugHud.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Wastelands.BaseMode;
+using Wastelands.Core.Management;
+using Wastelands.Core.Services;
+
+namespace Wastelands.BaseMode.Unity
+{
+    [AddComponentMenu("Wastelands/Base Scene Debug HUD")]
+    public sealed class BaseSceneDebugHud : MonoBehaviour
+    {
+        private BaseRuntimeState? _runtime;
+        private IBaseIndirectCommandDispatcher? _dispatcher;
+        private ITimeProvider? _timeProvider;
+        private IDisposable? _bootSubscription;
+        private IDisposable? _dispatcherSubscription;
+        private Vector2 _scrollPosition;
+
+        private void OnEnable()
+        {
+            if (!Application.isPlaying)
+            {
+                return;
+            }
+
+            Subscribe();
+        }
+
+        private void OnDisable()
+        {
+            _bootSubscription?.Dispose();
+            _dispatcherSubscription?.Dispose();
+            _bootSubscription = null;
+            _dispatcherSubscription = null;
+            _runtime = null;
+            _dispatcher = null;
+        }
+
+        private void Subscribe()
+        {
+            try
+            {
+                var services = DeterministicServicesProvider.Container;
+                _timeProvider = services.TimeProvider;
+                _bootSubscription = services.EventBus.Subscribe<BaseSceneBootstrapped>(OnBootstrapped);
+                _dispatcherSubscription = services.EventBus.Subscribe<BaseIndirectCommandDispatcherReady>(OnDispatcherReady);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"BaseSceneDebugHud failed to subscribe: {ex}");
+            }
+        }
+
+        private void OnBootstrapped(BaseSceneBootstrapped evt)
+        {
+            _runtime = evt.Runtime;
+        }
+
+        private void OnDispatcherReady(BaseIndirectCommandDispatcherReady evt)
+        {
+            _dispatcher = evt.Dispatcher;
+        }
+
+        private void OnGUI()
+        {
+            if (_runtime == null)
+            {
+                return;
+            }
+
+            var area = new Rect(10f, 10f, 360f, Screen.height - 20f);
+            GUILayout.BeginArea(area, GUI.skin.box);
+            GUILayout.Label("Base Mode Debug");
+            GUILayout.Label($"Tick: {_timeProvider?.CurrentTick ?? 0}");
+            GUILayout.Label($"Population: {_runtime.BaseState.Population.Count}");
+            GUILayout.Space(6f);
+
+            GUILayout.Label("Zones");
+            _scrollPosition = GUILayout.BeginScrollView(_scrollPosition, GUILayout.Height(220f));
+            foreach (var zone in _runtime.EnumerateZones())
+            {
+                GUILayout.BeginVertical(GUI.skin.box);
+                GUILayout.Label($"{zone.Zone.Name} ({zone.Zone.Id})");
+                GUILayout.Label($"Morale: {zone.MoraleModifier:0.00}  Wear: {zone.Wear:0.00}");
+                GUILayout.Label($"Workforce: {zone.WorkforceAllocation:0.00}");
+
+                if (_dispatcher != null && GUILayout.Button("Boost Morale"))
+                {
+                    IssueCommand("zone.adjust_morale", zone.Zone.Id, "delta", "0.1");
+                }
+
+                if (_dispatcher != null && GUILayout.Button("Schedule Inspection"))
+                {
+                    IssueCommand("zone.schedule_inspection", zone.Zone.Id);
+                }
+
+                GUILayout.EndVertical();
+            }
+
+            GUILayout.EndScrollView();
+            GUILayout.Space(6f);
+
+            GUILayout.Label("Jobs");
+            foreach (var job in _runtime.JobBoard.Jobs.Take(5))
+            {
+                GUILayout.BeginHorizontal();
+                GUILayout.Label($"{job.Id} ({job.Type})", GUILayout.Width(200f));
+                GUILayout.Label($"ETA: {job.RemainingHours}h", GUILayout.Width(80f));
+                if (_dispatcher != null && GUILayout.Button("Rush"))
+                {
+                    IssueCommand("job.rush", job.Id, "duration", "-1");
+                }
+
+                GUILayout.EndHorizontal();
+            }
+
+            GUILayout.Space(6f);
+            GUILayout.Label("Mandates");
+            foreach (var mandate in _runtime.MandateTracker.Mandates.Take(5))
+            {
+                GUILayout.BeginHorizontal();
+                GUILayout.Label($"{mandate.Id} [{mandate.State}]");
+                if (_dispatcher != null && GUILayout.Button("Acknowledge"))
+                {
+                    IssueCommand("mandate.acknowledge", mandate.Id);
+                }
+
+                GUILayout.EndHorizontal();
+            }
+
+            if (_dispatcher != null)
+            {
+                GUILayout.Space(6f);
+                GUILayout.Label("Recent Commands");
+                foreach (var command in _dispatcher.RecentCommands.Reverse().Take(5))
+                {
+                    GUILayout.Label($"{command.CommandType} -> {command.TargetId}");
+                }
+            }
+
+            GUILayout.EndArea();
+        }
+
+        private void IssueCommand(string commandType, string targetId, string? payloadKey = null, string? payloadValue = null)
+        {
+            if (_dispatcher == null)
+            {
+                return;
+            }
+
+            var payload = new Dictionary<string, string>(StringComparer.Ordinal);
+            if (!string.IsNullOrEmpty(payloadKey) && payloadValue != null)
+            {
+                payload[payloadKey] = payloadValue;
+            }
+
+            _dispatcher.Issue(new BaseIndirectCommand(commandType, targetId, payload));
+        }
+    }
+}

--- a/Assets/_Project/Scripts/BaseMode/Unity/BaseSceneInstallerBehaviour.cs
+++ b/Assets/_Project/Scripts/BaseMode/Unity/BaseSceneInstallerBehaviour.cs
@@ -1,0 +1,124 @@
+using System;
+using UnityEngine;
+using Wastelands.BaseMode;
+using Wastelands.Core.Data;
+using Wastelands.Core.Management;
+using Wastelands.Generation;
+using Wastelands.Persistence;
+
+namespace Wastelands.BaseMode.Unity
+{
+    [AddComponentMenu("Wastelands/Base Scene Installer")]
+    public sealed class BaseSceneInstallerBehaviour : MonoBehaviour
+    {
+        [Header("World Snapshot")]
+        [SerializeField] private TextAsset? worldSnapshot;
+
+        [Header("Runtime Settings")]
+        [SerializeField] private int hoursPerDay = 24;
+        [SerializeField] private bool autoAdvanceTicks = true;
+        [SerializeField] private int ticksPerFrame = 1;
+
+        [Header("Generated World Defaults")]
+        [SerializeField] private int worldWidth = 24;
+        [SerializeField] private int worldHeight = 16;
+        [SerializeField] private ApocalypseType apocalypseType = ApocalypseType.RadiantStorm;
+
+        private bool _bootstrapped;
+        private BaseSceneBootstrapper? _bootstrapper;
+        private WorldData? _overrideWorld;
+
+        public bool HasBootstrapped => _bootstrapped;
+        public BaseSceneBootstrapper? Bootstrapper => _bootstrapper;
+        public bool AutoAdvanceTicks { get => autoAdvanceTicks; set => autoAdvanceTicks = value; }
+        public int TicksPerFrame { get => ticksPerFrame; set => ticksPerFrame = Mathf.Max(0, value); }
+        public int HoursPerDay { get => hoursPerDay; set => hoursPerDay = Mathf.Max(1, value); }
+
+        public void SetWorld(WorldData world)
+        {
+            _overrideWorld = world ?? throw new ArgumentNullException(nameof(world));
+        }
+
+        public void BootstrapNow()
+        {
+            if (_bootstrapped)
+            {
+                return;
+            }
+
+            try
+            {
+                var services = DeterministicServicesProvider.Container;
+                var world = ResolveWorldData(services);
+                _bootstrapper = new BaseSceneBootstrapper(world, services, hoursPerDay: hoursPerDay);
+                _bootstrapper.Initialize();
+                _bootstrapped = true;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"Failed to bootstrap Base scene: {ex}");
+            }
+        }
+
+        private WorldData ResolveWorldData(DeterministicServiceContainer services)
+        {
+            if (_overrideWorld != null)
+            {
+                return _overrideWorld;
+            }
+
+            if (worldSnapshot != null && !string.IsNullOrWhiteSpace(worldSnapshot.text))
+            {
+                var serializer = new WorldDataSerializer();
+                return serializer.Deserialize(worldSnapshot.text);
+            }
+
+            var config = new OverworldGenerationConfig(
+                seed: (ulong)(uint)services.RngService.Seed,
+                width: Mathf.Max(4, worldWidth),
+                height: Mathf.Max(4, worldHeight),
+                apocalypse: apocalypseType);
+
+            var pipeline = new OverworldGenerationPipeline(services.RngService);
+            return pipeline.Generate(config);
+        }
+
+        private void Start()
+        {
+            if (!Application.isPlaying)
+            {
+                return;
+            }
+
+            BootstrapNow();
+        }
+
+        private void Update()
+        {
+            if (!Application.isPlaying || !autoAdvanceTicks || !_bootstrapped)
+            {
+                return;
+            }
+
+            var services = DeterministicServicesProvider.Container;
+            var steps = Mathf.Max(0, ticksPerFrame);
+            for (var i = 0; i < steps; i++)
+            {
+                services.TickManager.Advance();
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (!Application.isPlaying)
+            {
+                return;
+            }
+
+            if (_bootstrapper?.SimulationLoop != null)
+            {
+                DeterministicServicesProvider.Container.TickManager.UnregisterSystem(_bootstrapper.SimulationLoop);
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/BaseMode/Unity/Wastelands.BaseMode.Unity.asmdef
+++ b/Assets/_Project/Scripts/BaseMode/Unity/Wastelands.BaseMode.Unity.asmdef
@@ -1,0 +1,18 @@
+{
+  "name": "Wastelands.BaseMode.Unity",
+  "references": [
+    "Wastelands.BaseMode",
+    "Wastelands.Core",
+    "Wastelands.Generation",
+    "Wastelands.Persistence"
+  ],
+  "optionalUnityReferences": [],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "noEngineReferences": false
+}

--- a/Tests/EditMode/BaseSceneBootstrapperCommandTests.cs
+++ b/Tests/EditMode/BaseSceneBootstrapperCommandTests.cs
@@ -1,0 +1,47 @@
+using NUnit.Framework;
+using Wastelands.BaseMode;
+using Wastelands.Core.Management;
+using Wastelands.Core.Services;
+
+namespace Wastelands.Tests.EditMode
+{
+    public class BaseSceneBootstrapperCommandTests
+    {
+        [Test]
+        public void Initialize_PublishesDispatcherEventAndBindsRuntime()
+        {
+            var world = SampleWorldBuilder.CreateValidWorld();
+            var services = CreateServices();
+            var bootstrapper = new BaseSceneBootstrapper(world, services);
+
+            BaseRuntimeState? runtimeFromEvent = null;
+            IBaseIndirectCommandDispatcher? dispatcherFromEvent = null;
+            BaseIndirectCommand? publishedCommand = null;
+
+            using var runtimeSubscription = services.EventBus.Subscribe<BaseSceneBootstrapped>(evt => runtimeFromEvent = evt.Runtime);
+            using var dispatcherSubscription = services.EventBus.Subscribe<BaseIndirectCommandDispatcherReady>(evt => dispatcherFromEvent = evt.Dispatcher);
+            using var commandSubscription = services.EventBus.Subscribe<BaseIndirectCommandQueued>(evt => publishedCommand = evt.Command);
+
+            bootstrapper.Initialize();
+
+            Assert.IsNotNull(runtimeFromEvent);
+            Assert.IsNotNull(dispatcherFromEvent);
+            Assert.AreSame(bootstrapper.CommandDispatcher, dispatcherFromEvent);
+            Assert.AreSame(bootstrapper.Runtime!.CommandDispatcher, dispatcherFromEvent);
+
+            dispatcherFromEvent!.Issue(new BaseIndirectCommand("test.command", targetId: "zone_hab"));
+            Assert.IsNotNull(publishedCommand);
+            Assert.AreEqual("test.command", publishedCommand?.CommandType);
+            Assert.AreEqual("zone_hab", publishedCommand?.TargetId);
+        }
+
+        private static DeterministicServiceContainer CreateServices()
+        {
+            var timeProvider = new ManualTimeProvider(ticksPerYear: 1, ticksPerDay: 24);
+            var rng = new DeterministicRngService(9876);
+            var eventBus = new EventBus();
+            var tickManager = new TickManager(timeProvider, rng, eventBus);
+            return new DeterministicServiceContainer(timeProvider, rng, eventBus, tickManager);
+        }
+    }
+}

--- a/Tests/PlayMode/BaseSceneIndirectCommandSmokeTests.cs
+++ b/Tests/PlayMode/BaseSceneIndirectCommandSmokeTests.cs
@@ -1,0 +1,149 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Wastelands.BaseMode;
+using Wastelands.BaseMode.Unity;
+using Wastelands.Core.Data;
+using Wastelands.Core.Management;
+using Wastelands.UI.Bootstrap;
+
+namespace Wastelands.Tests.PlayMode
+{
+    public class BaseSceneIndirectCommandSmokeTests
+    {
+        private DeterministicServiceInstaller? _installer;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _installer = ScriptableObject.CreateInstance<DeterministicServiceInstaller>();
+            _installer.Install();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_installer != null)
+            {
+                _installer.ResetContainer();
+                ScriptableObject.DestroyImmediate(_installer);
+                _installer = null;
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator InstallerPublishesDispatcherAndAcceptsCommands()
+        {
+            var world = CreateWorld();
+            var go = new GameObject("BaseSceneInstaller");
+            var installer = go.AddComponent<BaseSceneInstallerBehaviour>();
+            installer.AutoAdvanceTicks = false;
+            installer.SetWorld(world);
+            go.AddComponent<BaseSceneDebugHud>();
+
+            BaseRuntimeState? runtime = null;
+            IBaseIndirectCommandDispatcher? dispatcher = null;
+            BaseIndirectCommand? issuedCommand = null;
+
+            using var runtimeSubscription = DeterministicServicesProvider.Container.EventBus.Subscribe<BaseSceneBootstrapped>(evt => runtime = evt.Runtime);
+            using var dispatcherSubscription = DeterministicServicesProvider.Container.EventBus.Subscribe<BaseIndirectCommandDispatcherReady>(evt => dispatcher = evt.Dispatcher);
+            using var commandSubscription = DeterministicServicesProvider.Container.EventBus.Subscribe<BaseIndirectCommandQueued>(evt => issuedCommand = evt.Command);
+
+            installer.BootstrapNow();
+            yield return null;
+
+            Assert.IsNotNull(runtime, "Runtime should be published after bootstrapping.");
+            Assert.IsNotNull(dispatcher, "Dispatcher should be provided for indirect commands.");
+
+            dispatcher!.Issue(new BaseIndirectCommand("debug.test", targetId: "zone_hab"));
+            yield return null;
+
+            Assert.IsNotNull(issuedCommand, "Issuing a command should publish a queued event.");
+            Assert.AreEqual("debug.test", issuedCommand?.CommandType);
+            Assert.AreEqual("zone_hab", issuedCommand?.TargetId);
+
+            Object.DestroyImmediate(go);
+        }
+
+        private static WorldData CreateWorld()
+        {
+            var tile = new Tile
+            {
+                Id = "tile_0_0",
+                Position = new Int2(0, 0),
+                BiomeId = "biome_desert",
+                HazardTags = new List<string> { "dust" }
+            };
+
+            var faction = new Faction
+            {
+                Id = "fac_alpha",
+                Name = "Alpha",
+                Archetype = FactionArchetype.Nomads,
+                NobleRoster = new List<NobleRoleAssignment>(),
+                Relations = new List<RelationRecord>()
+            };
+
+            var settlement = new Settlement
+            {
+                Id = "set_01",
+                FactionId = faction.Id,
+                TileId = tile.Id,
+                Population = 10,
+                Economy = new EconomyProfile { Production = 1f, Trade = 0.5f, Research = 0.2f }
+            };
+
+            var character = new Character
+            {
+                Id = "char_leader",
+                Name = "Leader",
+                FactionId = faction.Id,
+                Traits = new List<TraitId> { TraitId.Stoic },
+                Skills = new Dictionary<SkillId, SkillLevel>
+                {
+                    { SkillId.Leadership, new SkillLevel { Level = 3, Experience = 5, Aptitude = 1f } }
+                },
+                Relationships = new List<RelationshipRecord>()
+            };
+
+            faction.NobleRoster.Add(new NobleRoleAssignment { CharacterId = character.Id, Role = NobleRole.Overseer });
+            faction.Holdings.Add(settlement.Id);
+
+            var world = new WorldData
+            {
+                Seed = 42,
+                Tiles = new List<Tile> { tile },
+                Factions = new List<Faction> { faction },
+                Settlements = new List<Settlement> { settlement },
+                Characters = new List<Character> { character },
+                OracleState = new OracleState(),
+                Legends = new List<LegendEntry>(),
+                BaseState = new BaseState
+                {
+                    Active = true,
+                    SiteTileId = tile.Id,
+                    Zones = new List<BaseZone>
+                    {
+                        new() { Id = "zone_hab", Name = "Hab", Type = ZoneType.Habitat, Efficiency = 1f }
+                    },
+                    Population = new List<string> { character.Id },
+                    Infrastructure = new Dictionary<string, float> { { "power", 1f } },
+                    Inventory = new List<ItemStack>(),
+                    AlertLevel = AlertLevel.Calm,
+                    Research = new ResearchState
+                    {
+                        CompletedProjects = new List<string>(),
+                        ActiveProjectId = "tech_drills",
+                        ActiveProgress = 0.5f
+                    }
+                }
+            };
+
+            faction.Relations.Add(new RelationRecord { TargetFactionId = faction.Id, Standing = 1f, State = RelationState.Allied });
+
+            return world;
+        }
+    }
+}

--- a/Tests/PlayMode/Wastelands.Tests.PlayMode.asmdef
+++ b/Tests/PlayMode/Wastelands.Tests.PlayMode.asmdef
@@ -4,6 +4,8 @@
     "Wastelands.Core",
     "Wastelands.Simulation",
     "Wastelands.BaseMode",
+    "Wastelands.BaseMode.Unity",
+    "Wastelands.UI",
     "UnityEngine.TestRunner"
   ],
   "optionalUnityReferences": [


### PR DESCRIPTION
## Summary
- introduce a base-mode indirect command dispatcher with event bus signals and runtime bindings
- add Unity-facing installer and debug HUD MonoBehaviours that bootstrap the base scene and surface zone/job/mandate state with command buttons
- cover dispatcher wiring with new edit-mode and play-mode smoke tests and update the play-mode test assembly references

## Testing
- Not run (Unity Editor required)

------
https://chatgpt.com/codex/tasks/task_e_68dd12754de08329a1b44a079561d286