### PR TITLE
Update README with current milestone status

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,19 @@ This repository now includes the Unity project scaffold alongside the design doc
 - Follow the branching and PR process described in `docs/CONTRIBUTING.md`.
 - Preserve determinism and testability seams (RNG, Time, IO) in all systems.
 
-## What Exists Now
-- Documentation of design pillars, world generation, AI, social systems, mechanic context, architecture, and test plan.
-- Unity project settings under `ProjectSettings/` and scoped assembly definition files inside `Assets/_Project/Scripts/`.
-- Deterministic core services (time provider, RNG, event bus) and tick manager scaffolding with corresponding EditMode unit tests.
-- Folder structure and placeholder assets that align with the planned Unity layout, plus a Unity-focused `.gitignore`.
+## Current State
+- Documentation of design pillars, world generation, AI, social systems, mechanic context, architecture, and test plan remains the single source of truth for feature intent and contributor expectations.【F:docs/ARCHITECTURE.md†L1-L8】【F:docs/DESIGN.md†L1-L9】
+- Unity project settings, scoped assembly definitions, and deterministic core services (time provider, RNG, event bus, tick manager) are in place to support reproducible simulation systems and automated EditMode coverage.【F:Assets/_Project/Scripts/Core/Management/TickManager.cs†L1-L80】【F:Assets/_Project/Scripts/Core/Management/DeterministicServiceContainer.cs†L1-L77】
+- The overworld generation pipeline now creates normalized worlds with factions, settlements, characters, oracle hooks, and base state seeds, backed by deterministic serialization tests.【F:Assets/_Project/Scripts/Generation/OverworldGenerationPipeline.cs†L9-L120】【F:Tests/EditMode/OverworldGenerationPipelineTests.cs†L9-L35】
+- A multi-phase overworld simulation loop mutates world state, emits tick/legend events, and is validated for deterministic behavior through EditMode tests.【F:Assets/_Project/Scripts/Simulation/OverworldSimulationLoop.cs†L1-L126】【F:Tests/EditMode/OverworldSimulationLoopTests.cs†L9-L47】
+- Base Mode scaffolding—including the scene bootstrapper, runtime state container, job/mandate trackers, and tick-driven simulation loop—exists in code with deterministic tests, but the gameplay-facing systems (zones, raids, UI) are still stubs awaiting production assets and integration.【F:Assets/_Project/Scripts/BaseMode/BaseSceneBootstrapper.cs†L9-L63】【F:Assets/_Project/Scripts/BaseMode/BaseRuntimeState.cs†L9-L205】【F:Tests/EditMode/BaseModeSimulationLoopTests.cs†L9-L67】
+- Persistence seams support serializing and snapshotting overworld data for future save/load integration work.【F:Assets/_Project/Scripts/Persistence/OverworldSnapshotGateway.cs†L1-L124】【F:Tests/EditMode/BaseStateDiffTests.cs†L9-L73】
 
 ## What Comes Next
-1. **M1 (current)**: Harden the code scaffold by expanding data containers and integration seams for overworld/base systems.
-2. **M2**: Implement overworld generation and simulation loop with legends logging and persistence seams.
-3. **M3**: Deliver base mode MVP with zones, jobs, raids, and comprehensive test coverage.
+The team is transitioning from Milestone M2 to Milestone M3. Overworld generation, simulation, and persistence deliverables are implemented, while Base Mode gameplay systems remain to be built. Immediate priorities include:
 
-See `docs/ROADMAP.md` for detailed milestone descriptions and risk mitigation strategies.
+1. Wiring the Base scene to consume generated `WorldData`, expose player-interactive systems, and extend UI scaffolding.
+2. Implementing Base Mode systems (zones, jobs, raids, mandates) outlined in `docs/BASE_MODE.md`, ensuring they cooperate with the deterministic tick manager.
+3. Expanding persistence to cover combined overworld/base state diffs and providing round-trip save/load coverage.
+
+Refer to `docs/ROADMAP.md` and `docs/RELEASE_STATUS.md` for detailed milestone tracking and acceptance evidence.【F:docs/RELEASE_STATUS.md†L1-L33】【F:docs/ROADMAP.md†L1-L46】


### PR DESCRIPTION
## Summary
- refresh the README "Current State" section to describe the implemented overworld generation, simulation, base-mode scaffolding, and persistence work
- update the roadmap callouts to note that the project is transitioning from Milestone M2 into M3 with remaining base-mode deliverables

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68dd12ce45548329be78bbd8a41c56d8