### PR TITLE
Add base site context ingestion and hazard modifiers

### DIFF
--- a/Assets/_Project/Scripts/BaseMode/BaseSceneBootstrapper.cs
+++ b/Assets/_Project/Scripts/BaseMode/BaseSceneBootstrapper.cs
@@ -42,7 +42,9 @@ namespace Wastelands.BaseMode
             var baseState = _world.BaseState ?? throw new InvalidOperationException("World data is missing BaseState.");
             baseState.Active = true;
 
-            Runtime = new BaseRuntimeState(_world, baseState, _hoursPerDay);
+            var siteContext = BuildSiteContext(_world, baseState);
+            Runtime = new BaseRuntimeState(_world, baseState, _hoursPerDay, siteContext);
+            ApplySiteModifiers(Runtime);
             Runtime.SeedInitialJobs();
             Runtime.SeedInitialMandates(_world);
             Runtime.BindCommandDispatcher(_commandDispatcher);
@@ -67,6 +69,139 @@ namespace Wastelands.BaseMode
                 new RaidThreatSystem(),
                 new MandateResolutionSystem()
             };
+        }
+
+        private static BaseSiteContext BuildSiteContext(WorldData world, BaseState baseState)
+        {
+            if (string.IsNullOrEmpty(baseState.SiteTileId))
+            {
+                return BaseSiteContext.Empty;
+            }
+
+            var tilesById = world.Tiles.ToDictionary(tile => tile.Id, StringComparer.Ordinal);
+            if (!tilesById.TryGetValue(baseState.SiteTileId, out var siteTile))
+            {
+                return BaseSiteContext.Empty;
+            }
+
+            var hazards = siteTile.HazardTags ?? new List<string>();
+            var biomeId = siteTile.BiomeId ?? string.Empty;
+
+            var factionLookup = world.Factions.ToDictionary(faction => faction.Id, faction => faction.Name, StringComparer.Ordinal);
+            var nearbyFactions = world.Settlements
+                .Select(settlement => CreateFactionProximity(settlement, siteTile, tilesById, factionLookup))
+                .Where(proximity => proximity != null)
+                .Select(proximity => proximity!)
+                .OrderBy(proximity => proximity.Distance)
+                .Take(5)
+                .ToArray();
+
+            return new BaseSiteContext(biomeId, hazards, nearbyFactions);
+        }
+
+        private static BaseNearbyFaction? CreateFactionProximity(Settlement settlement, Tile siteTile, IReadOnlyDictionary<string, Tile> tilesById, IReadOnlyDictionary<string, string> factionLookup)
+        {
+            if (!tilesById.TryGetValue(settlement.TileId, out var settlementTile))
+            {
+                return null;
+            }
+
+            var factionId = settlement.FactionId ?? string.Empty;
+            factionLookup.TryGetValue(factionId, out var factionName);
+            var distance = ComputeDistance(siteTile.Position, settlementTile.Position);
+            return new BaseNearbyFaction(factionId, factionName ?? factionId, distance);
+        }
+
+        private static float ComputeDistance(Int2 a, Int2 b)
+        {
+            var dx = a.X - b.X;
+            var dy = a.Y - b.Y;
+            return (float)Math.Sqrt(dx * dx + dy * dy);
+        }
+
+        private static void ApplySiteModifiers(BaseRuntimeState runtime)
+        {
+            var baseState = runtime.BaseState;
+            foreach (var hazard in runtime.SiteContext.Hazards)
+            {
+                ApplyHazardModifier(baseState, hazard);
+            }
+        }
+
+        private static void ApplyHazardModifier(BaseState baseState, string hazardId)
+        {
+            switch (hazardId)
+            {
+                case "haz_solar_scorch":
+                    AdjustInfrastructure(baseState, "water", -0.15f);
+                    AdjustZoneEfficiency(baseState, ZoneType.Farm, -0.1f);
+                    break;
+                case "haz_sporefall":
+                    AdjustInfrastructure(baseState, "morale", -0.1f);
+                    AdjustZoneEfficiency(baseState, ZoneType.Habitat, -0.05f);
+                    break;
+                case "haz_radiant_flux":
+                    AdjustInfrastructure(baseState, "morale", -0.12f);
+                    AdjustInfrastructure(baseState, "defense", -0.1f);
+                    AdjustZoneEfficiency(baseState, ZoneType.Watchtower, -0.05f);
+                    break;
+                case "haz_nanite_bloom":
+                    AdjustInfrastructure(baseState, "power", -0.12f);
+                    AdjustZoneEfficiency(baseState, ZoneType.Workshop, -0.07f);
+                    break;
+                case "haz_void_rupture":
+                    AdjustInfrastructure(baseState, "morale", -0.12f);
+                    AdjustZoneEfficiency(baseState, ZoneType.ResearchLab, -0.08f);
+                    break;
+                case "haz_hollow_winds":
+                    AdjustInfrastructure(baseState, "defense", -0.1f);
+                    AdjustZoneEfficiency(baseState, ZoneType.Watchtower, -0.07f);
+                    break;
+                case "haz_unknown":
+                    AdjustInfrastructure(baseState, "water", -0.05f);
+                    AdjustInfrastructure(baseState, "morale", -0.05f);
+                    break;
+                default:
+                    if (hazardId.StartsWith("haz_", StringComparison.Ordinal))
+                    {
+                        AdjustInfrastructure(baseState, "power", -0.05f);
+                    }
+
+                    break;
+            }
+        }
+
+        private static void AdjustInfrastructure(BaseState baseState, string key, float delta)
+        {
+            if (!baseState.Infrastructure.TryGetValue(key, out var value))
+            {
+                value = 0.5f;
+            }
+
+            baseState.Infrastructure[key] = Clamp(value + delta, 0f, 1.5f);
+        }
+
+        private static void AdjustZoneEfficiency(BaseState baseState, ZoneType zoneType, float delta)
+        {
+            foreach (var zone in baseState.Zones.Where(z => z.Type == zoneType))
+            {
+                zone.Efficiency = Clamp(zone.Efficiency + delta, 0.3f, 1.5f);
+            }
+        }
+
+        private static float Clamp(float value, float min, float max)
+        {
+            if (value < min)
+            {
+                return min;
+            }
+
+            if (value > max)
+            {
+                return max;
+            }
+
+            return value;
         }
     }
 

--- a/Tests/EditMode/BaseSceneBootstrapperSiteContextTests.cs
+++ b/Tests/EditMode/BaseSceneBootstrapperSiteContextTests.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Wastelands.BaseMode;
+using Wastelands.Core.Data;
+using Wastelands.Core.Management;
+using Wastelands.Core.Services;
+
+namespace Wastelands.Tests.EditMode
+{
+    public class BaseSceneBootstrapperSiteContextTests
+    {
+        [Test]
+        public void Initialize_PopulatesSiteContextFromWorldMetadata()
+        {
+            var world = SampleWorldBuilder.CreateValidWorld();
+            world.Tiles[0].BiomeId = "biome_fungal_forest";
+            world.Tiles[0].HazardTags = new List<string> { "haz_sporefall", "haz_solar_scorch" };
+
+            world.Tiles.Add(new Tile
+            {
+                Id = "tile_1_0",
+                Position = new Int2(1, 0),
+                BiomeId = "biome_glass_desert",
+                HazardTags = new List<string>()
+            });
+
+            world.Factions.Add(new Faction
+            {
+                Id = "fac_beta",
+                Name = "Beta",
+                Archetype = FactionArchetype.Raiders,
+                NobleRoster = new List<NobleRoleAssignment>(),
+                Relations = new List<RelationRecord>()
+            });
+
+            world.Settlements.Add(new Settlement
+            {
+                Id = "set_02",
+                FactionId = "fac_beta",
+                TileId = "tile_1_0",
+                Population = 80,
+                Economy = new EconomyProfile { Production = 0.6f, Trade = 0.4f, Research = 0.2f }
+            });
+
+            var services = CreateServices();
+            var bootstrapper = new BaseSceneBootstrapper(world, services);
+
+            bootstrapper.Initialize();
+
+            Assert.IsNotNull(bootstrapper.Runtime);
+            var context = bootstrapper.Runtime!.SiteContext;
+            Assert.AreEqual("biome_fungal_forest", context.BiomeId);
+            CollectionAssert.AreEquivalent(new[] { "haz_sporefall", "haz_solar_scorch" }, context.Hazards);
+            Assert.AreEqual(2, context.NearbyFactions.Count);
+            Assert.AreEqual("fac_alpha", context.NearbyFactions[0].FactionId);
+            Assert.That(context.NearbyFactions[0].Distance, Is.EqualTo(0f).Within(0.0001f));
+            Assert.AreEqual("fac_beta", context.NearbyFactions[1].FactionId);
+            Assert.Greater(context.NearbyFactions[1].Distance, 0f);
+        }
+
+        [Test]
+        public void Initialize_AppliesHazardModifiersToBaseState()
+        {
+            var world = SampleWorldBuilder.CreateValidWorld();
+            world.Tiles[0].HazardTags = new List<string> { "haz_solar_scorch", "haz_sporefall" };
+
+            world.BaseState.Infrastructure["water"] = 1f;
+            world.BaseState.Infrastructure["morale"] = 1f;
+            world.BaseState.Infrastructure["defense"] = 1f;
+            world.BaseState.Zones.Add(new BaseZone { Id = "zone_farm", Name = "Farm", Type = ZoneType.Farm, Efficiency = 1f });
+            world.BaseState.Zones.Add(new BaseZone { Id = "zone_watch", Name = "Watch", Type = ZoneType.Watchtower, Efficiency = 1f });
+
+            var services = CreateServices();
+            var bootstrapper = new BaseSceneBootstrapper(world, services);
+
+            bootstrapper.Initialize();
+
+            var baseState = bootstrapper.Runtime!.BaseState;
+            Assert.That(baseState.Infrastructure["water"], Is.LessThan(1f));
+            Assert.That(baseState.Infrastructure["morale"], Is.LessThan(1f));
+
+            var farm = baseState.Zones.Single(z => z.Id == "zone_farm");
+            Assert.That(farm.Efficiency, Is.LessThan(1f));
+
+            var habitat = baseState.Zones.Single(z => z.Id == "zone_hab");
+            Assert.That(habitat.Efficiency, Is.LessThan(1f));
+        }
+
+        private static DeterministicServiceContainer CreateServices()
+        {
+            var timeProvider = new ManualTimeProvider(ticksPerYear: 1, ticksPerDay: 24);
+            var rng = new DeterministicRngService(9876);
+            var eventBus = new EventBus();
+            var tickManager = new TickManager(timeProvider, rng, eventBus);
+            return new DeterministicServiceContainer(timeProvider, rng, eventBus, tickManager);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ingest world site metadata into the base runtime site context and surface nearby factions and hazards
- apply hazard-driven infrastructure and zone efficiency modifiers during base scene bootstrap
- add edit mode coverage for site context hydration and hazard modifier application

## Testing
- not run (Unity tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd2eb9404c8329b5d2d3e4768fd423