### PR TITLE
Add documentation index and refresh milestone status

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 - **Core Loop**: Generate world → Survey history → Embark → Manage base with indirect orders → Respond to raids/disasters → Oracle AI draws from event decks → Return to overworld → Expand influence → Unite world.
 - **Fail State**: Leader permadeath or total faction collapse.
 
-## Repository Usage
-This repository now includes the Unity project scaffold alongside the design documentation. Project settings, assembly definitions, and core deterministic services are in place to support forthcoming overworld and base mode systems. Use the documents in `docs/` to understand the intended architecture, systems, and testing strategy while the early runtime foundation comes together.
+## Documentation & Orientation
+The repository ships with both the Unity project scaffold and an extensive design corpus. Start with `docs/README.md` for a topic-by-topic index that links architecture overviews, system design references, contributor process guides, and milestone status reports.【F:docs/README.md†L1-L47】 Keep this top-level `README.md` aligned with those artifacts whenever large features land so newcomers can trust it as the authoritative entry point.
 
 ## Contribution Rules
 - Read `docs/ARCHITECTURE.md`, `docs/TEST_PLAN.md`, and `docs/NAMING.md` before contributing.
@@ -32,14 +32,14 @@ This repository now includes the Unity project scaffold alongside the design doc
 - Unity project settings, scoped assembly definitions, and deterministic core services (time provider, RNG, event bus, tick manager) are in place to support reproducible simulation systems and automated EditMode coverage.【F:Assets/_Project/Scripts/Core/Management/TickManager.cs†L1-L80】【F:Assets/_Project/Scripts/Core/Management/DeterministicServiceContainer.cs†L1-L77】
 - The overworld generation pipeline now creates normalized worlds with factions, settlements, characters, oracle hooks, and base state seeds, backed by deterministic serialization tests.【F:Assets/_Project/Scripts/Generation/OverworldGenerationPipeline.cs†L9-L120】【F:Tests/EditMode/OverworldGenerationPipelineTests.cs†L9-L35】
 - A multi-phase overworld simulation loop mutates world state, emits tick/legend events, and is validated for deterministic behavior through EditMode tests.【F:Assets/_Project/Scripts/Simulation/OverworldSimulationLoop.cs†L1-L126】【F:Tests/EditMode/OverworldSimulationLoopTests.cs†L9-L47】
-- Base Mode scaffolding—including the scene bootstrapper, runtime state container, job/mandate trackers, and tick-driven simulation loop—exists in code with deterministic tests, but the gameplay-facing systems (zones, raids, UI) are still stubs awaiting production assets and integration.【F:Assets/_Project/Scripts/BaseMode/BaseSceneBootstrapper.cs†L9-L63】【F:Assets/_Project/Scripts/BaseMode/BaseRuntimeState.cs†L9-L205】【F:Tests/EditMode/BaseModeSimulationLoopTests.cs†L9-L67】
+- Base Mode scaffolding—including the scene bootstrapper, runtime state container, simulation systems for zones/jobs/raids/mandates, and deterministic EditMode coverage—runs today, but Unity UI and player command surfaces remain debug-only.【F:Assets/_Project/Scripts/BaseMode/BaseSceneBootstrapper.cs†L39-L61】【F:Assets/_Project/Scripts/BaseMode/Systems/BaseModeSystems.cs†L42-L390】【F:Tests/EditMode/BaseModeSimulationLoopTests.cs†L13-L71】【F:Assets/_Project/Scripts/BaseMode/Unity/BaseSceneDebugHud.cs†L9-L135】
 - Persistence seams support serializing and snapshotting overworld data for future save/load integration work.【F:Assets/_Project/Scripts/Persistence/OverworldSnapshotGateway.cs†L1-L124】【F:Tests/EditMode/BaseStateDiffTests.cs†L9-L73】
 
 ## What Comes Next
-The team is transitioning from Milestone M2 to Milestone M3. Overworld generation, simulation, and persistence deliverables are implemented, while Base Mode gameplay systems remain to be built. Immediate priorities include:
+Milestone M3 centers on turning the deterministic Base Mode scaffolding into a player-facing loop. Immediate priorities include:
 
-1. Wiring the Base scene to consume generated `WorldData`, expose player-interactive systems, and extend UI scaffolding.
-2. Implementing Base Mode systems (zones, jobs, raids, mandates) outlined in `docs/BASE_MODE.md`, ensuring they cooperate with the deterministic tick manager.
-3. Expanding persistence to cover combined overworld/base state diffs and providing round-trip save/load coverage.
+1. Replace the debug HUD with production UI that surfaces jobs, mandates, raids, and Oracle events while invoking the indirect command dispatcher provided by the scene bootstrapper.【F:Assets/_Project/Scripts/BaseMode/BaseSceneBootstrapper.cs†L39-L61】【F:Assets/_Project/Scripts/BaseMode/Unity/BaseSceneDebugHud.cs†L11-L160】
+2. Extend persistence so overworld and base state snapshots travel together, building on the existing overworld gateway before UI-driven saves ship.【F:Assets/_Project/Scripts/Persistence/OverworldSnapshotGateway.cs†L7-L83】
+3. Flesh out Oracle incident handling, ensuring injected incidents from deck draws have gameplay-visible effects and telemetry beyond the current tension adjustments and command hooks.【F:Assets/_Project/Scripts/BaseMode/Systems/OracleSynchronizer.cs†L8-L162】【F:Tests/EditMode/BaseModeSimulationLoopTests.cs†L53-L70】
 
-Refer to `docs/ROADMAP.md` and `docs/RELEASE_STATUS.md` for detailed milestone tracking and acceptance evidence.【F:docs/RELEASE_STATUS.md†L1-L33】【F:docs/ROADMAP.md†L1-L46】
+Refer to `docs/ROADMAP.md` and `docs/RELEASE_STATUS.md` for milestone tracking and delivery evidence.【F:docs/ROADMAP.md†L1-L46】【F:docs/RELEASE_STATUS.md†L1-L33】

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,43 @@
+# Documentation Index
+
+This index points to the authoritative design, engineering, and process references that live in this repository. Treat it as the table of contents for the "Desert Wastes" documentation corpus.
+
+## Orientation & Vision
+- `README.md` – high-level pitch, current status snapshot, and upcoming priorities for the simulation project.
+- `docs/DESIGN.md` – narrative pillars, player fantasy, and systems overview for the world unification simulator.
+- `docs/ARCHITECTURE.md` – layered runtime plan, service boundaries, and determinism requirements for Unity assemblies.
+
+## Systems & Simulation References
+- `docs/WORLDGEN.md` – procedural world generation flow, including apocalypse synthesis and faction seeding rules.
+- `docs/BASE_MODE.md` – day-to-day base simulation loop, zone definitions, job/mandate flows, and raid escalation rules.
+- `docs/AI_COMBAT_INDIRECT.md` – indirect combat, Oracle intervention decks, and commander intent propagation.
+- `docs/SOCIAL_NOBLES.md` – noble hierarchy, relationship dynamics, and social pressure systems that feed Base Mode decisions.
+- `docs/MECHANIC_CONTEXT.md` – cross-cutting mechanics that bridge overworld and base play (resources, stressors, morale).
+- `docs/DATA_MODEL.md` – canonical `WorldData` schema and deterministic serialization expectations used by services and tests.
+
+## Engineering & Implementation Guides
+- `docs/LOCAL_SETUP.md` – editor requirements, package cache tips, and troubleshooting steps for getting the Unity project running locally.
+- `docs/CI_PIPELINE.md` – Unity Test Runner automation guidance, licensing secrets, and NUnit export expectations for CI.
+- `docs/TEST_PLAN.md` – deterministic testing strategy, fixture management, and coverage expectations for overworld/base systems.
+- `docs/NAMING.md` – code, asset, and data naming conventions shared across assemblies.
+
+## Contribution Process
+- `docs/CONTRIBUTING.md` – branching strategy, workflow checklist, and commit message conventions for feature work.
+- `docs/CHECKLISTS.md` – Definition of Done checklists for features, tests, documentation, and accessibility reviews.
+- `docs/INPUTS_AND_ACCESSIBILITY.md` – input device plans and accessibility considerations to evaluate with every contribution.
+
+## Planning & Status Artifacts
+- `docs/ROADMAP.md` – milestone sequencing, risk register, and dependency notes for upcoming work.
+- `docs/RELEASE_STATUS.md` – milestone-by-milestone delivery evidence and the current release stage summary.
+- `docs/STATUS_REPORT.md` – latest runtime/test coverage evaluation and prioritized risks across systems.
+- `docs/MILESTONE_EVALUATION.md` – milestone acceptance criteria and evidence tying runtime features back to goals.
+
+## Scene & Content Resources
+- `docs/SCENES_AND_FLOW.md` – planned Unity scenes, bootstrapping order, and navigation flow between overworld and base.
+- `docs/BASE_MODE.md` & `docs/SCENES_AND_FLOW.md` – zone layout expectations and transition triggers.
+- `docs/STATUS_REPORT.md` & `docs/ROADMAP.md` – references for planning cross-checks when updating content or milestones.
+
+## Updating the Documentation
+- When adding systems or pipelines, update the relevant system doc (`docs/BASE_MODE.md`, `docs/WORLDGEN.md`, etc.) and add a short summary to `README.md` and `docs/RELEASE_STATUS.md`.
+- Keep deterministic evidence current: link new tests and runtime code in `docs/STATUS_REPORT.md` and `docs/MILESTONE_EVALUATION.md` as features evolve.
+- Use this index to verify whether a new document fits an existing category before creating a new file; consolidating updates under existing headings keeps the corpus navigable.

--- a/docs/RELEASE_STATUS.md
+++ b/docs/RELEASE_STATUS.md
@@ -3,8 +3,8 @@
 _Last updated: 2025-10-15_
 
 ## Current Stage Summary
-- **Stage**: Preparing Milestone M3 – Base Mode MVP (not started).
-- **Rationale**: Overworld generation and simulation deliverables are implemented with deterministic coverage. The pipeline produces normalized worlds, the multi-phase overworld loop mutates state and publishes events, and snapshot persistence seams are wired with serializer gateways and tests. Base mode integration work has not yet begun.
+- **Stage**: Milestone M3 – Base Mode MVP (simulation scaffolding in progress).
+- **Rationale**: Overworld generation, overworld simulation, and persistence seams are complete. Base Mode now boots into a deterministic runtime with systems for zones, jobs, raids, mandates, and Oracle incidents under EditMode coverage, but the experience is still surfaced through a debug HUD and lacks production UI plus save/load for base state.【F:Assets/_Project/Scripts/Generation/OverworldGenerationPipeline.cs†L9-L94】【F:Assets/_Project/Scripts/Simulation/OverworldSimulationLoop.cs†L57-L103】【F:Assets/_Project/Scripts/Persistence/OverworldSnapshotGateway.cs†L7-L83】【F:Assets/_Project/Scripts/BaseMode/BaseSceneBootstrapper.cs†L39-L61】【F:Assets/_Project/Scripts/BaseMode/Systems/BaseModeSystems.cs†L42-L390】【F:Tests/EditMode/BaseModeSimulationLoopTests.cs†L13-L71】【F:Assets/_Project/Scripts/BaseMode/Unity/BaseSceneDebugHud.cs†L11-L160】
 
 ## Milestone Breakdown
 
@@ -13,12 +13,12 @@ _Last updated: 2025-10-15_
 | **M0 – Docs & Scaffolding** | Documentation set (design, architecture, tests), project scaffolding, Unity-focused `.gitignore`, placeholder assets | ✅ Complete | `docs/` design docs, refreshed `README.md`, Unity folder layout in `Assets/` and `ProjectSettings/` |
 | **M1 – Code Scaffold** | Unity project settings, assembly definitions, deterministic services, TickManager, baseline data containers with tests | ✅ Complete | `ProjectSettings/*.asset`, asmdefs in `Assets/_Project/Scripts/**`, deterministic services & tick manager (`Assets/_Project/Scripts/Core/**`), data containers + normalizer (`Assets/_Project/Scripts/Core/Data/*.cs`), persistence & installer coverage in `Tests/EditMode/*.cs` |
 | **M2 – Overworld Gen + Sim** | World generation pipeline, overworld simulation loop, legends logging, persistence seams with tests | ✅ Complete | `Assets/_Project/Scripts/Generation/OverworldGenerationPipeline.cs`, `Assets/_Project/Scripts/Simulation/**`, persistence gateway in `Assets/_Project/Scripts/Persistence/OverworldSnapshotGateway.cs`, deterministic tests in `Tests/EditMode/OverworldGenerationPipelineTests.cs` & `Tests/EditMode/OverworldSimulationLoopTests.cs` |
-| **M3 – Base Mode MVP** | Base scene systems (zones, jobs, raids, social mandates), Oracle integration, comprehensive save/load & tests | ⏳ Not started | Base mode gameplay systems not yet implemented |
+| **M3 – Base Mode MVP** | Base scene systems (zones, jobs, raids, social mandates), Oracle integration, comprehensive save/load & tests | 🚧 In progress | Simulation scaffolding, Oracle hooks, and deterministic tests exist; production UI and persistence expansion outstanding.【F:Assets/_Project/Scripts/BaseMode/Systems/BaseModeSystems.cs†L42-L390】【F:Assets/_Project/Scripts/BaseMode/Systems/OracleSynchronizer.cs†L8-L162】【F:Tests/EditMode/BaseModeSimulationLoopTests.cs†L13-L71】 |
 
-## Key Gating Items to Kick Off M3
-1. Define the base scene bootstrap that consumes `WorldData` outputs and seeds `BaseState` structures for player interaction.
-2. Implement core Base Mode systems (zones, jobs, raids, mandates) per `docs/BASE_MODE.md`, ensuring deterministic tick integration with the overworld loop.
-3. Extend persistence coverage to include Base Mode state diffs and round-trip save/load of combined overworld/base data.
+## Key Gating Items to Exit M3
+1. Ship production UI and input loops that replace the debug HUD while leveraging the indirect command dispatcher and runtime systems seeded by the bootstrapper.【F:Assets/_Project/Scripts/BaseMode/BaseSceneBootstrapper.cs†L39-L61】【F:Assets/_Project/Scripts/BaseMode/Unity/BaseSceneDebugHud.cs†L11-L160】
+2. Expand persistence coverage to serialize combined overworld/base state and verify deterministic round-trips in EditMode suites.【F:Assets/_Project/Scripts/Persistence/OverworldSnapshotGateway.cs†L7-L83】【F:Tests/EditMode/BaseModeSimulationLoopTests.cs†L35-L70】
+3. Implement gameplay-visible Oracle incident handlers and deck balancing loops so injected incidents impact base state beyond tension adjustments.【F:Assets/_Project/Scripts/BaseMode/Systems/OracleSynchronizer.cs†L8-L162】【F:Assets/_Project/Scripts/BaseMode/Systems/BaseModeSystems.cs†L221-L390】
 
 ## Recommended Next Steps
 - Align simulation tick cadence with planned Base Mode systems to avoid conflicting mutations.


### PR DESCRIPTION
## Summary
- add a documentation index in `docs/README.md` that links the existing design, engineering, and process artifacts
- update the repository README to point at the index, clarify current Base Mode coverage, and outline M3 priorities
- refresh `docs/RELEASE_STATUS.md` to mark Base Mode scaffolding progress and highlight the remaining exit gates for Milestone M3

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68dd505af9f48329a906133093aad123