### PR TITLE
Update design documentation to match current implementation

### DIFF
--- a/docs/AI_COMBAT_INDIRECT.md
+++ b/docs/AI_COMBAT_INDIRECT.md
@@ -37,14 +37,14 @@ Players set intents, priorities, and doctrines. Units interpret orders based on 
 - Deterministic RNG ensures reproducible outcomes for testing (`docs/TEST_PLAN.md`).
 
 ## Oracle AI Interventions
-- **Role**: A semi-divine overseer AI acts as a game master, drawing from tiered event decks (Minor, Major, Epic) to escalate or ease pressure based on world tension metrics.
+- **Role**: The `OracleReviewPhase` inside `OverworldSimulationLoop` monitors world tension, adjusts deck weights, and emits deterministic `OracleIncidentInjected` payloads when thresholds are crossed.
 - **Event Decks**:
-  - *Minor*: Tactical twists (reinforcement delays, sandstorms, morale visions) that alter immediate combat modifiers.
-  - *Major*: Strategic shifts (enemy champions, supply boons, diplomatic ultimatums) that ripple across overworld simulation.
-  - *Epic*: Campaign-defining events (Rise of a Nemesis commander, apocalyptic omen, divine respite) that reconfigure long-term goals.
-- **Trigger Logic**: Deck selection uses deterministic thresholds tied to simulation stress, noble mandates, and player choices to preserve testability and fairness (`docs/ARCHITECTURE.md`).
-- **Delivery**: Interventions manifest as orders relayed through command hierarchy, environmental modifiers, or narrative events logged into legends.
-- **Player Response**: Players receive limited countermeasures (rituals, diplomacy, intel) to anticipate the Oracle's next draw.
+  - *Minor*: Tactical twists (reinforcement delays, sandstorms, morale visions) applied by `OracleIncidentResolutionSystem` as infrastructure/morale nudges and temporary raid modifiers.
+  - *Major*: Strategic shifts (enemy champions, supply boons, diplomatic ultimatums) that update overworld factions and Base Mode threat meters.
+  - *Epic*: Campaign-defining events (Rise of a Nemesis commander, apocalyptic omen, divine respite) that inject multi-step incidents and legends entries.
+- **Trigger Logic**: Deck selection uses deterministic thresholds tied to Oracle tension, mandate outcomes, and raid results to preserve testability (`docs/ARCHITECTURE.md`). Cooldowns and deck weights are normalized after each incident.
+- **Delivery**: `OracleSynchronizer` publishes incidents to Base Mode, where `OracleIncidentResolutionSystem` applies effect payloads and adjusts deck weights/cooldowns. Overworld incidents route through event logs and faction state.
+- **Player Response**: Players counter by pursuing mandates, patrol jobs, and infrastructure upgrades that lower tension or add defensive buffers before the next draw.
 
 ## Cross-References
 - Social impacts: `docs/SOCIAL_NOBLES.md`

--- a/docs/BASE_MODE.md
+++ b/docs/BASE_MODE.md
@@ -8,24 +8,23 @@
 5. **Site Selection**: Evaluate site viability via biome data, hazards, and proximity to factions.
 6. **Commit**: Generate base map chunk and transition into Base scene (see `docs/SCENES_AND_FLOW.md`).
 
-## Core Systems
-- **Zones**: DF-style designations (housing, workshops, storage, agriculture, defense).
-- **Jobs & Labor**: Work orders prioritized by command hierarchy; players set intents, AI handles execution.
-- **Industries**: Crafting chains (salvage → refinement → production → research) with resource dependencies.
-- **Research**: Unlock tech tiers affecting overworld influence and base resilience.
-- **Hazards**: Environmental threats (storms, toxins), mechanical failures, raids triggered by overworld state.
-- **Oracle Incursions**: Event cards manifest as miracles or calamities (supply caches, nemesis assaults, morale visions) depending on deck tier draws (`docs/AI_COMBAT_INDIRECT.md`).
-- **Infrastructure**: Power, water, sanitation, morale spaces to maintain settlement stability.
+## Core Systems (Runtime Implementation)
+- **Zone Maintenance**: `ZoneMaintenanceSystem` iterates every designated `BaseZoneRuntime`, applying morale drift, wear, and efficiency deltas based on infrastructure levels and seeded RNG channels. Watchtowers bleed the raid threat meter while infrastructure decay nudges the player to schedule upkeep.
+- **Jobs & Labor**: `JobSchedulingSystem` advances queued `BaseJob`s, emits deterministic `BaseJobCompleted` events, and applies outcomes that touch infrastructure, inventory, and research state. Patrol jobs suppress raid threat; production jobs mint inventory stacks used by mandates and incidents.
+- **Raid Threat**: `RaidThreatSystem` manages a tension-driven meter that schedules raids once thresholds are crossed. Resolved raids publish `BaseRaidResolved` events, adjust infrastructure, and funnel results into the Oracle synchronizer for deck balancing.
+- **Mandates**: `MandateResolutionSystem` consumes mandate tracker resolutions, applies infrastructure/resource deltas, enqueues follow-ups, logs legend-ready events, and forwards outcomes to the Oracle for tension adjustments.
+- **Oracle Incidents**: `OracleIncidentResolutionSystem` subscribes to `OracleIncidentInjected` events, enforces card cooldowns, clamps deck weights, and applies effect payloads (resource injections, morale swings, raid modifiers) directly to `BaseState`.
+- **Infrastructure Backbone**: Base infrastructure values (power, water, morale, defense) feed multiple systems—zones, raids, mandates—creating a feedback loop that rewards proactive maintenance.
 
-## Time Scales
-- **Overworld**: Yearly ticks, aggregated events (handled in Simulation layer).
-- **Base Mode**: Daily ticks with sub-hour granular scheduling for jobs and incidents.
-- Synchronization occurs via state exchanges when transitioning scenes (see `docs/ARCHITECTURE.md`).
+## Time Scales & Ticks
+- **Overworld**: `OverworldSimulationLoop` advances yearly ticks before Base Mode begins, populating Oracle tension and raid seeds.
+- **Base Mode**: `BaseModeSimulationLoop` executes once per daily tick, exposing an hourly cadence via `BaseModeTickContext.HoursPerDay` for systems that subdivide work (jobs, raids, incidents).
+- **Synchronization**: `BaseSceneBootstrapper` normalizes incoming `WorldData`, builds `BaseRuntimeState`, and registers the base loop with the deterministic `TickManager` so overworld-to-base transitions share RNG/time seams (`docs/ARCHITECTURE.md`).
 
 ## Raids & Defense
-- **Alert Levels**: Normal, Elevated, Siege. Affects AI behavior and resource usage.
-- **Defense Prep**: Build traps, assign guard posts, manage patrol routes via indirect orders.
-- **Siege Phases**: Approach → Encirclement → Breach → Resolution. Each phase logs events to legends (see `docs/AI_COMBAT_INDIRECT.md`).
+- **Alert Levels**: `BaseState.AlertLevel` (Calm, Elevated, Critical) is mutated by raid scheduling/resolution and by mandate completions that focus on defense.
+- **Defense Prep**: Patrol jobs and infrastructure upgrades reduce the raid meter; failure to maintain defense infrastructure or morale accelerates raid scheduling.
+- **Resolution Logging**: Every raid resolution writes `EventRecord` entries with attacker IDs, alert levels, and post-raid tension, ensuring legends and telemetry remain synchronized (`docs/AI_COMBAT_INDIRECT.md`).
 
 ## Cross-References
 - Command AI: `docs/AI_COMBAT_INDIRECT.md`

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -93,7 +93,7 @@ WorldData
 | --- | --- | --- |
 | Id | string | Stable card identifier (e.g., `card_rise_nemesis`). |
 | Effects | List<EventEffect> | Declarative payload consumed by services (`docs/ARCHITECTURE.md`). |
-| Narrative | LocalizedStringId | Text surfaced in legends/alerts. |
+| Narrative | string | Narrative snippet written directly into legends/alerts. |
 
 ### ApocalypseMeta
 | Field | Type | Notes |

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -19,14 +19,14 @@
 
 ## Scope Planning
 
-| Feature Area | MVP Scope | Future Scope |
-| --- | --- | --- |
-| World Generation | Deterministic height/temp/moisture map, factions, relic sites, apocalypse hazards, legends log. | Dynamic weather, migrations, procedural story events, mod hooks. |
-| Overworld Simulation | Yearly ticks for faction expansion, diplomacy, trade, raids. | Multi-faction diplomacy UI, espionage, cultural diffusion. |
-| Base Mode | DF-style zones, job assignments, industries, research queue, raids. | Multi-layer bases, advanced automation, noble courts. |
-| AI & Combat | Indirect orders, leadership modifiers, morale, command radius. | Complex doctrines, psychological warfare, advanced logistics. |
-| Social Systems | Personalities, needs, noble mandates, succession rules. | Festivals, religion, dynamic laws, player-made policies. |
-| Persistence | JSON snapshots, legends log export, manual saves/loads. | Cloud sync, replay viewer, timeline scrubbing. |
+| Feature Area | MVP Scope | Current Implementation Notes | Future Scope |
+| --- | --- | --- | --- |
+| World Generation | Deterministic height/temp/moisture map, factions, relic sites, apocalypse hazards, legends log. | `OverworldGenerationPipeline` builds tiles, factions, settlements, characters, oracle/base seeds, and normalizes data before handing to simulation. | Dynamic weather, migrations, procedural story events, mod hooks. |
+| Overworld Simulation | Yearly ticks for faction expansion, diplomacy, trade, raids. | `OverworldSimulationLoop` chains discrete phases (faction growth, trade, Oracle review) and logs deterministic events for legends and persistence. | Multi-faction diplomacy UI, espionage, cultural diffusion. |
+| Base Mode | DF-style zones, job assignments, industries, research queue, raids. | `BaseSceneBootstrapper` seeds `BaseRuntimeState`; modular systems (zones, jobs, raids, mandates, Oracle) execute each tick via `BaseModeSimulationLoop`. | Multi-layer bases, advanced automation, noble courts. |
+| AI & Combat | Indirect orders, leadership modifiers, morale, command radius. | Command intents travel through data-driven jobs/raids; Oracle incidents and raid threat tie into command hierarchy without direct control. | Complex doctrines, psychological warfare, advanced logistics. |
+| Social Systems | Personalities, needs, noble mandates, succession rules. | Mandate tracker & noble roles integrate with base/overworld state; incident effects adjust loyalty and infrastructure. | Festivals, religion, dynamic laws, player-made policies. |
+| Persistence | JSON snapshots, legends log export, manual saves/loads. | `OverworldSnapshotGateway` serializes deterministic `WorldData` snapshots; combined overworld/base save pipeline planned for M3 exit. | Cloud sync, replay viewer, timeline scrubbing. |
 
 ## Cross-References
 - Generation details: `docs/WORLDGEN.md`

--- a/docs/SCENES_AND_FLOW.md
+++ b/docs/SCENES_AND_FLOW.md
@@ -11,10 +11,10 @@ An additive UI scene provides HUD, overlays, and shared interface components acr
 
 ## State Flow
 1. **Boot**: Composition root initializes DI container, deterministic RNG streams, and Time provider (`docs/ARCHITECTURE.md`).
-2. **Generate**: World scene requests WorldData from Generation layer; deterministically creates map, factions, legends seeds.
-3. **Simulate**: Overworld ticks yearly, updating factions, logging events, and feeding tension metrics into the Oracle AI for potential deck draws.
+2. **Generate**: World scene requests `WorldData` from `OverworldGenerationPipeline`; factions, settlements, oracle/base seeds, and legends scaffolding are normalized before hand-off.
+3. **Simulate**: `OverworldSimulationLoop` runs yearly phases (faction growth, trade, Oracle review), logging deterministic events and updating Oracle tension for later incidents.
 4. **Embark**: Player selects leader, team, and site (`docs/BASE_MODE.md`).
-5. **Base**: Daily ticks manage jobs, hazards, raids, and Oracle-triggered incidents while writing events to legends.
+5. **Base**: `BaseSceneBootstrapper` constructs `BaseRuntimeState` and registers `BaseModeSimulationLoop`, whose modular systems manage jobs, raids, mandates, and Oracle incidents while writing events to legends.
 6. **Return**: On exit, Base state syncs back to World scene; overworld simulation resumes.
 
 ## Performance Notes

--- a/docs/SOCIAL_NOBLES.md
+++ b/docs/SOCIAL_NOBLES.md
@@ -6,9 +6,9 @@
 - **Relationships**: Friendship, rivalry, mentorship, kinship tracked via weighted scores and shared history events (`docs/DATA_MODEL.md`).
 
 ## Mood & Mandates
-- Moods derive from needs, recent events, leadership actions, and environment quality (`docs/BASE_MODE.md`).
-- Nobles and influential characters issue mandates (resource quotas, construction, policy shifts).
-- Compliance boosts loyalty; failure increases resentment and may trigger coups or desertion.
+- Moods derive from needs, recent events, leadership actions, and environment quality (`docs/BASE_MODE.md`). `BaseRuntimeState.MandateTracker` queues mandates seeded during bootstrap and from noble responses.
+- Nobles and influential characters issue mandates (resource quotas, construction, policy shifts) that resolve through `MandateResolutionSystem` with deterministic rewards/penalties.
+- Compliance boosts loyalty/infrastructure; failure increases resentment, drains morale infrastructure, and may elevate raid alert levels.
 
 ## Noble Roles
 | Role | Responsibilities | Failure Consequence |
@@ -26,8 +26,8 @@
 - Succession outcomes update legends log and influence faction diplomacy (`docs/WORLDGEN.md`).
 
 ## Social Simulation Hooks
-- Events pipeline integrates with architecture event bus (`docs/ARCHITECTURE.md`).
-- Tests validate mandate compliance logic and loyalty adjustments (`docs/TEST_PLAN.md`).
+- Events pipeline integrates with the deterministic event bus (`docs/ARCHITECTURE.md`). `BaseMandateResolved` events feed Oracle tension adjustments and legends logging.
+- EditMode tests cover mandate queuing/resolution and Oracle tension feedback via `BaseModeSimulationLoopTests` and `SampleWorldBuilder` fixtures (`docs/TEST_PLAN.md`).
 
 ## Cross-References
 - Data model specifics: `docs/DATA_MODEL.md`

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -8,32 +8,32 @@
 ## Unit Tests (EditMode)
 | Focus | Description | Related Docs |
 | --- | --- | --- |
-| Worldgen Determinism | Validate that given seed produces identical `WorldData` structures (`docs/WORLDGEN.md`, `docs/DATA_MODEL.md`). | `docs/WORLDGEN.md`, `docs/DATA_MODEL.md` |
-| Event Generation Invariants | Ensure events maintain referential integrity (actors, locations) and chronological ordering. | `docs/DATA_MODEL.md`, `docs/ARCHITECTURE.md` |
-| Command Outcome Distributions | Verify indirect combat outcomes align with expected probability distributions and leadership modifiers. | `docs/AI_COMBAT_INDIRECT.md` |
-| Social Mandate Resolution | Confirm mandates adjust loyalty/morale consistently with trait modifiers. | `docs/SOCIAL_NOBLES.md` |
-| Oracle Deck Selection | Assert `IOracleInterventionService` chooses decks/cards deterministically given tension thresholds and cooldowns. | `docs/AI_COMBAT_INDIRECT.md`, `docs/DATA_MODEL.md`, `docs/ARCHITECTURE.md` |
+| Deterministic Services | `DeterministicRngServiceTests`, `ManualTimeProviderTests`, and `TickManagerTests` ensure reproducible seeds/ticks and pub-sub wiring. | `docs/ARCHITECTURE.md`, `docs/DATA_MODEL.md` |
+| World Generation | `OverworldGenerationPipelineTests` validate tile/faction/site creation, oracle/base seeds, and normalization. | `docs/WORLDGEN.md`, `docs/DESIGN.md` |
+| Overworld Simulation | `OverworldSimulationLoopTests` exercise yearly phase ordering, Oracle tension adjustments, and legends output. | `docs/ARCHITECTURE.md`, `docs/AI_COMBAT_INDIRECT.md` |
+| Base Bootstrap & Loop | `BaseSceneBootstrapper*Tests` and `BaseModeSimulationLoopTests` verify runtime initialization, deterministic system execution, mandate/raid/oracle flows. | `docs/BASE_MODE.md`, `docs/SOCIAL_NOBLES.md`, `docs/AI_COMBAT_INDIRECT.md` |
+| Persistence | `OverworldSnapshotGatewayTests`, `WorldDataSerializerTests`, and `WorldDataValidatorTests` cover JSON round-trips and schema invariants. | `docs/DATA_MODEL.md`, `docs/ARCHITECTURE.md` |
 
 ## PlayMode Tests
 | Focus | Description | Related Docs |
 | --- | --- | --- |
-| Scene Boot | Load Boot → World → Base scenes ensuring DI services initialize and persist. | `docs/SCENES_AND_FLOW.md`, `docs/ARCHITECTURE.md` |
-| Tick Cadence | Validate overworld yearly ticks and base daily ticks maintain timing contract. | `docs/BASE_MODE.md`, `docs/ARCHITECTURE.md` |
-| Save/Load Round-Trip | Serialize `WorldData` and `BaseState`, reload, and compare for equality. | `docs/DATA_MODEL.md`, `docs/WORLDGEN.md` |
+| Scene Boot | `BaseSceneIndirectCommandSmokeTests` loads the Base scene, verifies bootstrap events, and issues indirect command samples. | `docs/SCENES_AND_FLOW.md`, `docs/BASE_MODE.md` |
+| Command Dispatch | Validate indirect command dispatcher wiring between UI Toolkit components and runtime services. | `docs/ARCHITECTURE.md`, `docs/BASE_MODE.md` |
+| Future Coverage | Save/load round-trips and overworld/base transitions will be added alongside persistence expansion. | `docs/DATA_MODEL.md`, `docs/ROADMAP.md` |
 
 ## Property-Based Tests
-- RNG wrapper: Ensure sequences are repeatable and cover distribution expectations (`docs/ARCHITECTURE.md`).
-- Oracle interventions: Generate random stress profiles and property-test that deck eligibility obeys tier rules (`docs/AI_COMBAT_INDIRECT.md`).
-- Legends log: Generate random event sequences and assert chronological order and referential integrity.
+- RNG wrapper: Property tests will complement `DeterministicRngServiceTests` by validating distribution bounds (`docs/ARCHITECTURE.md`).
+- Oracle interventions: Randomized stress profiles verify deck eligibility, cooldown recovery, and incident weight balancing (`docs/AI_COMBAT_INDIRECT.md`).
+- Legends log: Random event sequences assert chronological order and referential integrity once overworld/base telemetry expands.
 
 ## Test Data Strategy
-- Text-based fixtures (JSON) stored under `Tests/PlayMode/Fixtures/` (to be created in M1).
+- Text-based fixtures (JSON) stored under `Tests/PlayMode/Fixtures/`; placeholder assets ship with the repo for future expansion.
 - No binary assets; all references to textures/audio remain placeholders.
 - Use versioned fixture naming aligned with `WorldData.Version` (see `docs/DATA_MODEL.md`).
 
 ## Tooling & Automation
 - Unity Test Framework for EditMode & PlayMode suites.
-- Continuous Integration (planned in `.tools/`) runs tests on each PR.
+- Continuous Integration via `.github/workflows/unity-tests.yml` runs EditMode + PlayMode suites on each PR when license secrets are configured.
 - Coverage thresholds defined post-M1.
 
 ## Cross-References

--- a/docs/WORLDGEN.md
+++ b/docs/WORLDGEN.md
@@ -8,17 +8,17 @@
 
 ## Map Generation Pipeline
 1. **Seed Intake**: Single 64-bit seed enters deterministic RNG wrapper (see `docs/TEST_PLAN.md`).
-2. **Heightmap**: Generate base landmass using layered noise; enforce tectonic-style ridgelines.
-3. **Climate**: Derive temperature and moisture via latitude, elevation, and prevailing winds.
-4. **Biomes**: Map tiles to biomes using height/temp/moisture thresholds with apocalypse modifiers (e.g., scorched deserts, fungal forests).
-5. **Hazards**: Overlay apocalypse-type hazards (radiation zones, nanite storms) with weighted falloff.
-6. **Resources**: Place resource veins and relic caches with biome-specific tables.
+2. **Heightmap**: `GenerateTiles` samples deterministic noise channels (`worldgen.heightmap`) to produce height values and stable tile IDs.
+3. **Climate**: Temperature/moisture derive from latitude formulas plus channel noise (`worldgen.climate`).
+4. **Biomes**: `SelectBiome` categorizes tiles using height/temperature/moisture thresholds and apocalypse modifiers (scorched deserts, fungal forests).
+5. **Hazards**: `DetermineHazards` overlays apocalypse-specific tags (radiation zones, nanite storms) with channel weighting.
+6. **Resources**: `DetermineResources` injects biome-weighted supply nodes via `worldgen.resources` channel.
 
 ## Faction Seeding
 - Identify habitable clusters by biome and resource richness.
-- Assign faction archetypes (warlords, scholars, merchants) influenced by era events.
-- Determine leadership traits and noble lineages per faction.
-- Establish diplomacy predispositions (alliances, rivalries) for simulation seeding.
+- Assign faction archetypes (Nomads, Technocracy, Zealots, Guardians, etc.) using deterministic RNG seeded by faction index.
+- Determine leadership traits and noble lineages per faction; create leaders tied to `NobleRole` slots for immediate Base Mode use.
+- Establish diplomacy predispositions (alliances, rivalries) stored in `RelationRecord` collections for overworld simulation seeding.
 
 ## Relic & Hazard Sites
 - **Relic Sites**: Remnants of Pre-Fall tech with unique modifiers; require expedition-level skills.
@@ -39,3 +39,4 @@
 - Data schema: `docs/DATA_MODEL.md`
 - Simulation tick usage: `docs/ARCHITECTURE.md`
 - Testing strategy: `docs/TEST_PLAN.md`
+- Feature context: `docs/DESIGN.md`


### PR DESCRIPTION
## Summary
- refresh the design scope table with current implementation notes across world generation, simulation, base mode, and persistence
- expand architecture, base mode, world generation, and social system docs with concrete runtime systems and data flow details
- update the indirect combat, scene flow, and test plan guides to reflect the Oracle pipeline, bootstrap loop, and existing automated coverage

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68dd5e02e69c8329a31e4c0ff289d4b0